### PR TITLE
Fix temp file collisions during concurrent evals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,10 @@ function unescapeShell(str) {
   return str.replace(/\\!/g, '!');
 }
 
+function tmpName(prefix, ext) {
+  return join(tmpdir(), `${prefix}-${process.pid}-${Date.now()}-${randomBytes(6).toString('hex')}.${ext}`);
+}
+
 /**
  * If the JSX is a Frame whose role is "lay out N similar items in a row/col",
  * extract the children as independent JSX strings + the direction.
@@ -520,7 +524,7 @@ function figmaEvalSync(code) {
       // For simple expressions and multi-statement code, just pass through
       // The plugin will add return to the last statement
       const payload = JSON.stringify({ action: 'eval', code: wrappedCode });
-      const payloadFile = join(tmpdir(), `figma-payload-${Date.now()}.json`);
+      const payloadFile = tmpName('figma-payload', 'json');
       writeFileSync(payloadFile, payload);
       const daemonToken = getDaemonToken();
       const tokenHeader = daemonToken ? ` -H "X-Daemon-Token: ${daemonToken}"` : '';
@@ -552,8 +556,8 @@ function figmaEvalSync(code) {
   }
 
   // Fallback: direct connection via temp script
-  const tempFile = join(tmpdir(), `figma-eval-${Date.now()}.mjs`);
-  const resultFile = join(tmpdir(), `figma-result-${Date.now()}.json`);
+  const tempFile = tmpName('figma-eval', 'mjs');
+  const resultFile = tmpName('figma-result', 'json');
 
   // Use file:// URL for ESM import (cross-platform)
   const clientUrl = pathToFileURL(join(process.cwd(), 'src/figma-client.js')).href;


### PR DESCRIPTION
## Summary

- Generate unique temp filenames for eval payload, script, and result files.
- Include process id, timestamp, and random bytes to avoid filename collisions across concurrent CLI invocations.

## Why

Concurrent commands can create temp files in the same millisecond when filenames only use `Date.now()`. That can cause one process to read, overwrite, or remove another process's payload/result file.

## Validation

- `node --check src/index.js`
- `npm test`
- Ran multiple concurrent `verify` commands against different Figma frames and confirmed each returned the expected frame id/name.
- Ran multiple concurrent `eval` commands with distinct payloads and confirmed responses stayed isolated.