### PR TITLE
feat: add --port / FIGMA_PORT option for custom CDP port

### DIFF
--- a/src/commands/render.js
+++ b/src/commands/render.js
@@ -653,8 +653,8 @@ program
     }
 
     // 5. Remote debugging port
+    const cdpPort = getCdpPort();
     try {
-      const cdpPort = getCdpPort();
       const response = await fetch(`http://127.0.0.1:${cdpPort}/json/version`, { signal: AbortSignal.timeout(2000) });
       if (response.ok) {
         console.log(chalk.green(`✓ Remote debugging enabled (port ${cdpPort})`));
@@ -662,7 +662,6 @@ program
         console.log(chalk.red('✗ Remote debugging port not responding'));
       }
     } catch {
-      const cdpPort = getCdpPort();
       console.log(chalk.red(`✗ Remote debugging not available (port ${cdpPort} closed)`));
       console.log(chalk.gray('  → Run: node src/index.js connect'));
     }

--- a/src/commands/render.js
+++ b/src/commands/render.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'os';
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { FigmaClient } from '../figma-client.js';
 import { getFigmaVersion, isFigmaRunning, platformName } from '../platform.js';
+import { getCdpPort } from '../figma-patch.js';
 import {
   program,
   CONFIG_DIR,
@@ -653,14 +654,16 @@ program
 
     // 5. Remote debugging port
     try {
-      const response = await fetch('http://127.0.0.1:9222/json/version', { signal: AbortSignal.timeout(2000) });
+      const cdpPort = getCdpPort();
+      const response = await fetch(`http://127.0.0.1:${cdpPort}/json/version`, { signal: AbortSignal.timeout(2000) });
       if (response.ok) {
-        console.log(chalk.green('✓ Remote debugging enabled (port 9222)'));
+        console.log(chalk.green(`✓ Remote debugging enabled (port ${cdpPort})`));
       } else {
         console.log(chalk.red('✗ Remote debugging port not responding'));
       }
     } catch {
-      console.log(chalk.red('✗ Remote debugging not available (port 9222 closed)'));
+      const cdpPort = getCdpPort();
+      console.log(chalk.red(`✗ Remote debugging not available (port ${cdpPort} closed)`));
       console.log(chalk.gray('  → Run: node src/index.js connect'));
     }
 

--- a/src/figma-patch.js
+++ b/src/figma-patch.js
@@ -13,14 +13,11 @@ import {
   getFigmaCommand as platformGetFigmaCommand
 } from './platform.js';
 
-// Fixed CDP port (figma-use has 9222 hardcoded)
-const CDP_PORT = 9222;
+const DEFAULT_CDP_PORT = 9222;
 
-/**
- * Get the CDP port (always 9222 for figma-use compatibility)
- */
 export function getCdpPort() {
-  return CDP_PORT;
+  const envPort = parseInt(process.env.FIGMA_PORT, 10);
+  return (envPort > 0 && envPort < 65536) ? envPort : DEFAULT_CDP_PORT;
 }
 
 // The string that blocks remote debugging

--- a/src/figma-patch.js
+++ b/src/figma-patch.js
@@ -159,7 +159,7 @@ export function unpatchFigma() {
 /**
  * Get the command to start Figma with remote debugging
  */
-export function getFigmaCommand(port = 9222) {
+export function getFigmaCommand(port = getCdpPort()) {
   return platformGetFigmaCommand(port);
 }
 

--- a/src/lib/cli-core.js
+++ b/src/lib/cli-core.js
@@ -513,6 +513,15 @@ const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
 
 const program = new Command();
 
+program.option('--port <number>', 'CDP port for Figma connection (default: 9222, env: FIGMA_PORT)');
+
+program.hook('preAction', (thisCommand) => {
+  const opts = thisCommand.opts();
+  if (opts.port) {
+    process.env.FIGMA_PORT = String(opts.port);
+  }
+});
+
 // Helper: Prompt user
 function prompt(question) {
   const rl = createInterface({ input: process.stdin, output: process.stdout });

--- a/tests/cdp-port.test.js
+++ b/tests/cdp-port.test.js
@@ -1,0 +1,36 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('getCdpPort', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env.FIGMA_PORT;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.FIGMA_PORT;
+    } else {
+      process.env.FIGMA_PORT = originalEnv;
+    }
+  });
+
+  it('returns 9222 by default', async () => {
+    delete process.env.FIGMA_PORT;
+    const mod = await import(`../src/figma-patch.js?t=${Date.now()}`);
+    assert.equal(mod.getCdpPort(), 9222);
+  });
+
+  it('returns FIGMA_PORT when set', async () => {
+    process.env.FIGMA_PORT = '9333';
+    const { getCdpPort } = await import(`../src/figma-patch.js?t=${Date.now()}`);
+    assert.equal(getCdpPort(), 9333);
+  });
+
+  it('ignores invalid FIGMA_PORT values', async () => {
+    process.env.FIGMA_PORT = 'abc';
+    const { getCdpPort } = await import(`../src/figma-patch.js?t=${Date.now()}`);
+    assert.equal(getCdpPort(), 9222);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--port` flag and `FIGMA_PORT` env var to specify a custom Chrome DevTools Protocol port
- Default remains 9222 for backwards compatibility
- Fixes port conflicts when Chrome already uses 9222

## Motivation
Users running Chrome with `--remote-debugging-port=9222` cannot use figma-cli without a conflict. This is common for developers using browser automation tools.

## Changes
- `getCdpPort()` in `figma-patch.js` now reads `FIGMA_PORT` env var (validated, falls back to 9222)
- Added `--port <number>` global CLI option (sets `FIGMA_PORT` before command execution)
- Parameterized the hardcoded `9222` in `render.js` diagnostics
- `getFigmaCommand()` default now uses `getCdpPort()` instead of hardcoded `9222`

## Test plan
- [ ] New test: `tests/cdp-port.test.js` — verifies env var reading, default, and invalid input handling
- [ ] All existing tests pass unchanged
- [ ] Manual: `figma-cli --port 9333 connect` starts Figma on port 9333
- [ ] Manual: `FIGMA_PORT=9333 figma-cli connect` starts Figma on port 9333
- [ ] Manual: `figma-cli connect` still defaults to port 9222

🤖 Generated with [Claude Code](https://claude.com/claude-code)