### PR TITLE
Add Homebrew formula for figma-ds-cli

### DIFF
--- a/figma-ds-cli.rb
+++ b/figma-ds-cli.rb
@@ -1,0 +1,18 @@
+class FigmaDsCli < Formula
+  desc "CLI for managing Figma design systems — variables, components, tokens, no API key required"
+  homepage "https://github.com/silships/figma-cli"
+  url "https://github.com/silships/figma-cli/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "d6a9e4944cb98d38a4c537152cff0046f7e48d007f7fc806c0ad92d1eea8cc4e"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/figma-ds-cli --version")
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `figma-ds-cli.rb` Homebrew formula for v2.1.0
- Installs via `npm install` with Node.js as the only dependency
- Binary: `figma-ds-cli`

## Install

Once merged, users can install with:

```bash
brew tap silships/figma-cli https://github.com/silships/figma-cli
brew install figma-ds-cli
```

Or directly via the raw formula URL.

## Test plan

- [ ] `brew install --build-from-source figma-ds-cli.rb` completes without errors
- [ ] `figma-ds-cli --version` outputs `2.1.0`
- [ ] `brew test figma-ds-cli` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)