### PR TITLE
feat(plugin): make the repo installable as a Claude Code plugin + marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "intodesignsystems",
+  "owner": {
+    "name": "Sil Bormüller"
+  },
+  "description": "Figma tooling for AI coding agents from Into Design Systems.",
+  "plugins": [
+    {
+      "name": "figma-cli",
+      "source": "./",
+      "description": "Build and edit designs directly in Figma Desktop from your terminal — render frames/components/variants, manage design tokens & variables (shadcn/Tailwind/DTCG), extract & import whole design systems, gradients, Figma Motion, and accessibility audits. No API key.",
+      "version": "2.1.0",
+      "author": {
+        "name": "Sil Bormüller",
+        "url": "https://intodesignsystems.com"
+      },
+      "homepage": "https://github.com/silships/figma-cli",
+      "license": "MIT",
+      "category": "design",
+      "keywords": [
+        "figma",
+        "design-system",
+        "design-tokens",
+        "variables",
+        "components"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "figma-cli",
+  "version": "2.1.0",
+  "description": "Build and edit designs directly in Figma Desktop from your terminal — render frames/components/variants, manage design tokens & variables (shadcn/Tailwind/DTCG), extract & import whole design systems, gradients, Figma Motion, and accessibility audits. Controls Figma live over a local connection, no API key.",
+  "author": {
+    "name": "Sil Bormüller",
+    "url": "https://intodesignsystems.com"
+  },
+  "homepage": "https://github.com/silships/figma-cli",
+  "repository": "https://github.com/silships/figma-cli",
+  "license": "MIT",
+  "keywords": [
+    "figma",
+    "design-system",
+    "design-tokens",
+    "variables",
+    "components",
+    "cli"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### New
 
+- **Claude Code plugin + marketplace.** The repo is now installable as a Claude
+  Code plugin: `/plugin marketplace add silships/figma-cli` then
+  `/plugin install figma-cli@intodesignsystems`. Ships a `figma-cli` skill (the
+  condensed operating rules — connect modes, render/JSX, tokens, verify, a11y) so
+  Claude Code is fluent with the CLI in any project. Manifests live in
+  `.claude-plugin/` (`plugin.json` + `marketplace.json`); the skill lives in
+  `skills/figma-cli/`. The CLI itself is unchanged; the plugin only carries the
+  know-how (the local Node CLI still does the work).
 - **Variable-collection roundtrip.** `figma-cli extract` now captures the file's real variable collections , every variable with its true name, all its modes (light/dark, high-contrast, colour-blind, whatever the system defines) and its alias chains , into a `## Variables` section plus the machine-readable JSON token block. This is the authoritative token layer, not the palette sampled from fills. `figma-cli import` recreates those collections faithfully (modes and aliases included) in any other file, closing the variables roundtrip. Captured in bounded chunks so large systems (thousands of variables) don't time out, and aliases to library/remote variables resolve to their real names.
 - **`figma-cli extract --sections variables`** for a variables-only export.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ Claude builds it in Figma instantly.
 
 ---
 
+## Install as a Claude Code plugin (optional)
+
+Prefer Claude Code's plugin system? This repo is also a **plugin marketplace**, so
+Claude Code learns the figma-cli workflow in *any* project (not just this one) after
+a two-line install:
+
+```
+/plugin marketplace add silships/figma-cli
+/plugin install figma-cli@intodesignsystems
+```
+
+That installs a skill that teaches Claude Code how to drive figma-cli (connect
+modes, the render/JSX rules, tokens, verify, a11y). The **CLI itself still needs
+Node ≥ 18 and its dependencies** , clone this repo and run `npm install` once (or
+ask Claude to), then open Figma Desktop and say *"connect to Figma"*. The plugin
+supplies the know-how; the local CLI does the work.
+
+---
+
 ## Using Cursor
 
 Prefer **Cursor**? It works exactly the same , the CLI controls Figma Desktop, not your editor, so nothing about it is Claude-only. Most people use Claude Code, but if Cursor is your tool, here's the whole setup.

--- a/skills/figma-cli/SKILL.md
+++ b/skills/figma-cli/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: figma-cli
+description: Build and edit designs directly in Figma Desktop from the terminal using the figma-cli command (controls Figma live over a local connection, no API key). Use whenever the user wants to create, render, or edit Figma frames/components/variants, add or import design tokens/variables (shadcn, Tailwind, DTCG, CSS), extract a design system to DESIGN.md, generate gradients/wallpapers, animate with Figma Motion, run accessibility audits, or connect an AI assistant to their Figma. Triggers on "build/make X in Figma", "add my design system", "create N buttons/cards", "use my variables", "export the design system", "check contrast".
+---
+
+# Using figma-cli
+
+figma-cli controls **Figma Desktop** directly (no API key). It runs in any
+terminal. Open Figma Desktop, then `figma-cli connect` once per session.
+
+If the `figma-cli` command is not found, the tool isn't installed yet — see
+**Installation** at the bottom. Never show raw terminal commands to the user;
+run them silently and give friendly feedback.
+
+## Connect (pick one mode)
+- `figma-cli connect` — **Yolo** (default): patches Figma Desktop once, fully automatic.
+- `figma-cli connect --browser` — **Browser**: drives Figma in a Chromium browser via
+  a local connection; **never modifies the Figma app**. Use when patching the desktop
+  app is undesirable (compliance / locked-down machine / no "App Management" permission).
+- `figma-cli connect --safe` — **Safe**: official plugin (Plugins → Development → FigCli).
+
+## Golden rules
+1. **Create frames with `render` / `render-batch`** — they have smart positioning.
+   NEVER use `eval` to create visual nodes (no positioning, bypasses guards).
+2. **"N buttons/cards" = N separate top-level nodes**, not one wrapper frame
+   containing N children. Use `render-batch '[...]'` or `shadcn add <c> --count N`.
+3. **Never delete the user's existing nodes.**
+4. After creating, **verify**: `figma-cli verify "<id>" --measure` (returns a
+   screenshot + real w/h so you catch size bugs by numbers, not by eye).
+
+## Design tokens / variables
+- Bind colors at creation with `var:name`, never raw hex when a system is loaded:
+  `<Frame bg="var:primary"><Text color="var:on-primary">Go</Text></Frame>`
+- Pin a named collection when the user names one: `render-batch ... --collection figma`.
+- Import a system: `figma-cli import tailwind.config.js | globals.css | tokens.json`.
+- Export the open file's system: `figma-cli extract` → DESIGN.md.
+
+## JSX cheatsheet (render)
+- Layout: `flex="row|col" gap={16} p={24} px py pt pr pb pl justify="center|between" items="center"`
+- Size: `w={320} h={200} w="fill" w="hug" w="60%"` (percent resolves vs parent)
+- Look: `bg="#fff" stroke="#000" strokeWidth={2} rounded={12} shadow="..." opacity={0.8}`
+- Text: `<Text size={14} weight="semibold" color="#000" lineHeight={20} truncate maxLines={2} w="fill">`
+- Icons (real SVG, never emojis): `<Icon name="lucide:home" size={20} color="var:primary" />`
+- Dividers: a thin child (`<Frame w={1} bg="var:border" />`) auto-fills the cross axis.
+
+## Text wrapping (most common bug)
+For text to wrap, the parent AND every `<Text>` need `w="fill"`, and the parent
+needs `flex="col"` or `flex="row"`.
+
+## Recreating a component from an extracted DESIGN.md (hard rule)
+Don't read the structure markdown by hand. Use:
+- `figma-cli spec <Component>` → authoritative variant axes + sample size (compact).
+  Build EXACTLY to those axes (e.g. Variant × Size = a Component Set, not one node).
+- `figma-cli spec <Component> --check <nodeId>` → enforces it (exit 1 on mismatch:
+  wrong structure, missing axes, wrong height). Treat non-zero as "not done".
+
+## Handy commands
+```
+figma-cli connect                      # connect to Figma Desktop (yolo)
+figma-cli render '<Frame>...</Frame>'  # one frame
+figma-cli render-batch '[ "<Frame>", ... ]' --direction row
+figma-cli shadcn add button --count 3  # N distinct shadcn primitives
+figma-cli node to-component "<id>"     # promote to a component
+figma-cli verify "<id>" --measure      # screenshot + dimensions
+figma-cli a11y audit                   # contrast / touch / text checks
+figma-cli tokens preset shadcn         # 244 primitives + semantic (light/dark)
+figma-cli var visualize                # show colors on canvas
+figma-cli motion preset <id> fade-up   # animate (Figma Motion, beta)
+figma-cli blocks create dashboard-01   # pre-built dashboard layout
+```
+
+## Installation
+figma-cli is a Node CLI (Node ≥ 18) that talks to Figma Desktop locally. If the
+`figma-cli` binary is missing, get the project from
+https://github.com/silships/figma-cli and run `npm install` in it, then invoke it
+as `node src/index.js <command>` (or link it as `figma-cli`). Full command
+reference and JSX docs live in that repo's README.md and REFERENCE.md.


### PR DESCRIPTION
## Why

figma-cli's value with an AI assistant comes largely from the operating rules in `CLAUDE.md` / `init-agent` (connect modes, the render/JSX rules, "N items = N nodes", verify-by-numbers, spec enforcement). Today those only apply inside *this* repo. Packaging the repo as a **Claude Code plugin** lets any Claude Code user pull that fluency into **any** project with two lines, and puts figma-cli in the plugin-marketplace ecosystem.

## What

Makes the repo both a **plugin marketplace** and a **plugin** (at root):

```
/plugin marketplace add silships/figma-cli
/plugin install figma-cli@intodesignsystems
```

- **`.claude-plugin/plugin.json`** — plugin manifest (`name`, `version`, `author`, `homepage`, `license`, `keywords`).
- **`.claude-plugin/marketplace.json`** — marketplace manifest. The repo is both the marketplace (`name: "intodesignsystems"`) and a single plugin at root (`"source": "./"`).
- **`skills/figma-cli/SKILL.md`** — the skill Claude Code loads on Figma-related requests. It's the same condensed ruleset `init-agent` already writes to `AGENTS.md`/Cursor rules (connect modes incl. the new Browser Mode, render/JSX cheatsheet, tokens/`var:` binding, `verify --measure`, `spec --check`, a11y), plus a strong triggering `description` and an install/connect note.
- **README** — "Install as a Claude Code plugin (optional)" section.
- **CHANGELOG** — Unreleased entry.

## Scope / honesty

The **CLI itself is unchanged.** The plugin ships *know-how*, not the runtime: the local Node CLI (Node ≥ 18 + `npm install`) still does the actual Figma work. The skill says so explicitly, so users aren't surprised that installing the plugin doesn't install the binary. This keeps the PR small and truthful; a future step could add a real MCP facade or a bundled launcher.

## Validation

- `claude plugin validate . --strict` → **passed** (marketplace).
- `claude plugin validate .claude-plugin/plugin.json` → passed (one benign warning that the repo's own `CLAUDE.md` isn't loaded as plugin context — intended; shippable guidance lives in the skill).
- Both manifests parse; existing test suite unaffected (**274 pass / 0 fail**).

## Naming

Marketplace name `intodesignsystems` (brand-level, room for future plugins) → installs read as `figma-cli@intodesignsystems`. Plugin name `figma-cli`. Note: this is independent of the existing `plugin/` dir (the *Figma* plugin used by Safe Mode) — no collision.

> Note: since `plugin.json` pins an explicit `version` (`2.1.0`), bump it on release or users keep the cached copy. Omitting `version` would track commit SHAs instead — a choice for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)