### PR TITLE
fix(connect): don't quit a Figma that is already debuggable

### DIFF
--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -8,7 +8,8 @@ import { join, basename } from 'path';
 import { FigmaClient } from '../figma-client.js';
 import * as apiDocs from '../api-docs.js';
 import { isPatched, patchFigma, unpatchFigma, getCdpPort } from '../figma-patch.js';
-import { detectBrowser, startBrowserApp, getBrowserCommand } from '../platform.js';
+import { detectBrowser, startBrowserApp, getBrowserCommand, isFigmaRunning } from '../platform.js';
+import { resolveConnectAction } from '../lib/connect-plan.js';
 import { convert, detectSourceType } from '../code-import/index.js';
 import {
   program,
@@ -750,32 +751,54 @@ program
     // Stop any existing daemon
     stopDaemon();
 
-    console.log(chalk.blue('Starting Figma...'));
+    // Don't touch a Figma that is already debuggable. Quitting it costs the
+    // user their window arrangement and any unsaved state for nothing.
+    let cdpReachable = false;
     try {
-      killFigma();
-      await new Promise(r => setTimeout(r, 500));
+      const probe = await fetch(`http://localhost:${getCdpPort()}/json`, { signal: AbortSignal.timeout(2000) });
+      cdpReachable = probe.ok;
     } catch {}
 
-    startFigma();
-    console.log(chalk.green('✓ Figma started\n'));
+    const action = resolveConnectAction({ cdpReachable, figmaRunning: isFigmaRunning() });
 
-    // Wait and check connection
-    const spinner = ora('Waiting for connection...').start();
-    let connected = false;
-    for (let i = 0; i < 8; i++) {
-      await new Promise(r => setTimeout(r, 1000));
-      const result = figmaUse('status', { silent: true });
-      if (result && result.includes('Connected')) {
-        spinner.succeed('Connected to Figma');
-        console.log(chalk.gray(result.trim()));
-        connected = true;
-        break;
-      }
+    if (action === 'needs-quit') {
+      // Figma is up but without --remote-debugging-port. Only the user can
+      // quit it safely, so ask rather than kill.
+      console.log(chalk.yellow('\n  Figma is running, but the debug port is not open.'));
+      console.log(chalk.white('  Quit Figma (Cmd+Q), then run ') + chalk.cyan('connect') + chalk.white(' again.\n'));
+      return;
     }
 
-    if (!connected) {
-      spinner.warn('Open a file in Figma to connect');
-      return;
+    if (action === 'start-fresh') {
+      console.log(chalk.blue('Starting Figma...'));
+      try {
+        killFigma();
+        await new Promise(r => setTimeout(r, 500));
+      } catch {}
+
+      startFigma();
+      console.log(chalk.green('✓ Figma started\n'));
+
+      // Wait and check connection
+      const spinner = ora('Waiting for connection...').start();
+      let connected = false;
+      for (let i = 0; i < 8; i++) {
+        await new Promise(r => setTimeout(r, 1000));
+        const result = figmaUse('status', { silent: true });
+        if (result && result.includes('Connected')) {
+          spinner.succeed('Connected to Figma');
+          console.log(chalk.gray(result.trim()));
+          connected = true;
+          break;
+        }
+      }
+
+      if (!connected) {
+        spinner.warn('Open a file in Figma to connect');
+        return;
+      }
+    } else {
+      console.log(chalk.green('✓ Figma already running (left untouched)\n'));
     }
 
     // Start daemon for fast commands (force restart to get fresh connection)

--- a/src/lib/connect-plan.js
+++ b/src/lib/connect-plan.js
@@ -1,0 +1,30 @@
+/**
+ * Deciding what `connect` has to do to Figma before it can talk to it.
+ *
+ * Lives in its own module so the decision can be unit-tested: the connect
+ * command itself probes the CDP port and the process list, neither of which
+ * is available in a test run.
+ */
+
+/**
+ * What `connect` should do, given what is currently running.
+ *
+ * `connect` used to quit and relaunch Figma unconditionally. That costs the
+ * user their window arrangement and any unsaved state every time they run it —
+ * including the common case where Figma is already reachable and nothing needs
+ * to happen to it at all.
+ *
+ * @param {object} state
+ * @param {boolean} state.cdpReachable  the CDP port answered
+ * @param {boolean} state.figmaRunning  a Figma process exists
+ * @returns {'reuse'|'needs-quit'|'start-fresh'}
+ *   `reuse`       — Figma is already debuggable; leave it alone, just wire up the daemon.
+ *   `needs-quit`  — Figma runs without the debug port. Only the user can quit it
+ *                   safely (unsaved work), so ask instead of killing it.
+ *   `start-fresh` — no Figma at all; patch if needed and launch it ourselves.
+ */
+export function resolveConnectAction({ cdpReachable, figmaRunning }) {
+  if (cdpReachable) return 'reuse';
+  if (figmaRunning) return 'needs-quit';
+  return 'start-fresh';
+}

--- a/tests/connect-plan.test.js
+++ b/tests/connect-plan.test.js
@@ -1,0 +1,21 @@
+// Unit tests for the connect decision (pure, no Figma/CDP needed).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveConnectAction } from '../src/lib/connect-plan.js';
+
+test('a reachable CDP port means Figma is left alone', () => {
+  assert.equal(resolveConnectAction({ cdpReachable: true, figmaRunning: true }), 'reuse');
+});
+
+test('CDP wins even if the process probe missed Figma', () => {
+  // A reachable port proves a debuggable Figma exists, whatever pgrep says.
+  assert.equal(resolveConnectAction({ cdpReachable: true, figmaRunning: false }), 'reuse');
+});
+
+test('Figma running without the debug port asks the user to quit', () => {
+  assert.equal(resolveConnectAction({ cdpReachable: false, figmaRunning: true }), 'needs-quit');
+});
+
+test('no Figma at all means we start it ourselves', () => {
+  assert.equal(resolveConnectAction({ cdpReachable: false, figmaRunning: false }), 'start-fresh');
+});


### PR DESCRIPTION
## The problem

`connect` quits and relaunches Figma unconditionally:

```js
// src/commands/setup.js
stopDaemon();

console.log(chalk.blue('Starting Figma...'));
try {
  killFigma();
  await new Promise(r => setTimeout(r, 500));
} catch {}

startFigma();
```

That runs even when the CDP port is already answering and nothing needs to happen to Figma at all — which is the common case once you're set up. The cost is the user's window arrangement, their zoom/scroll position, and whatever hasn't synced yet. Running `connect` a second time "just to be sure" is a normal thing to do, and it shouldn't be destructive.

It also affects the recovery path people are told to take: when a command times out, restarting the daemon is usually enough, but `connect` looks like the safer, more thorough option — and it's the one that costs you your session.

## The change

`connect` probes the CDP port first and branches on what it finds:

| CDP reachable | Figma running | Action |
|---|---|---|
| yes | — | **reuse** — leave Figma alone, just start the daemon |
| no | yes | **needs-quit** — ask the user to quit (they may have unsaved work; killing it for them is not our call) |
| no | no | **start-fresh** — patch if needed and launch, exactly as before |

The `start-fresh` branch is the existing code, unchanged. Only the guard in front of it is new.

The decision itself is a pure function in `src/lib/connect-plan.js`, following the pattern of `browserDebugArgs` / `tests/browser-mode.test.js`, so it's unit-tested without a Figma or an open port:

```js
resolveConnectAction({ cdpReachable, figmaRunning })
// → 'reuse' | 'needs-quit' | 'start-fresh'
```

The process probe uses the existing `isFigmaRunning()` from `src/platform.js`, so it works on macOS, Windows and Linux. The port comes from `getCdpPort()`, so `--port` / `FIGMA_PORT` are honored.

## Verification

- `npm test` → 525 passing, including 4 new cases in `tests/connect-plan.test.js`
- All three branches confirmed against a real Figma Desktop:
  - **reuse** — Figma's PID and start time identical before and after `connect`; output `✓ Figma already running (left untouched)`, daemon reconnected
  - **needs-quit** — Figma running with an unpatched `app.asar`: `connect` printed the quit prompt and left the process alone
  - **start-fresh** — no Figma running: patched and launched as before

## Notes

Happy to adjust the wording of the `needs-quit` message, or to make it offer a `--force` flag that restores the old quit-and-relaunch behavior, if you'd rather keep an escape hatch.
