### PR TITLE
fix(render): unmask render errors and make w/h="fill" work (#42)

### DIFF
--- a/src/figma-client.js
+++ b/src/figma-client.js
@@ -2004,8 +2004,13 @@ export class FigmaClient {
         ${smartPosCode}
 
         let __currentNode = 'root';
+        // Declared OUTSIDE the try on purpose: the catch below cleans the frame
+        // up, and a const inside the try is not in scope there. That shadowing
+        // turned every render failure into "ReferenceError: frame is not
+        // defined" and left the half-built frame on the canvas.
+        let frame;
         try {
-        const frame = figma.createFrame();
+        frame = figma.createFrame();
         __currentNode = ${JSON.stringify(name)};
         frame.name = ${JSON.stringify(name)};
         frame.resize(${width}, ${height});
@@ -2058,7 +2063,9 @@ export class FigmaClient {
           ? { id: frame.id, name: frame.name, unresolved: __unresolved, layoutWarnings: __layoutWarnings }
           : { id: frame.id, name: frame.name };
         } catch(e) {
-          frame.remove();
+          // Guarded: createFrame() itself can throw, and a remove() that fails
+          // must not replace the real error.
+          if (frame) { try { frame.remove(); } catch (e2) {} }
           throw new Error('[Node: ' + __currentNode + '] ' + e.message);
         }
       })()

--- a/src/figma-client.js
+++ b/src/figma-client.js
@@ -7,6 +7,7 @@
 
 import WebSocket from 'ws';
 import { getCdpPort } from './figma-patch.js';
+import { resolveLeafSizing, resolveRootFill } from './lib/fill-sizing.js';
 
 /**
  * Visible fallback colors for shadcn semantic token names (Zinc light theme).
@@ -1637,8 +1638,14 @@ export class FigmaClient {
           })();` : ''}`;
         } else if (item._type === 'rect') {
           // Rectangle element
-          const rWidth = item.w || item.width || 100;
-          const rHeight = item.h || item.height || 100;
+          const rectParentNone = parentFlex === 'none' || parentFlex === 'stack' || parentFlex === 'free';
+          const rectSizing = resolveLeafSizing({
+            // `|| undefined` keeps the old falsy-means-default behaviour.
+            w: (item.w || item.width) || undefined, h: (item.h || item.height) || undefined,
+            defaultW: 100, defaultH: 100, parentIsNone: rectParentNone,
+          });
+          const rWidth = rectSizing.resizeW;
+          const rHeight = rectSizing.resizeH;
           const rBg = item.bg || item.fill || '#e4e4e7';
           const rRounded = item.rounded || item.radius || 0;
           const rName = item.name || 'Rectangle';
@@ -1651,13 +1658,20 @@ export class FigmaClient {
         el${idx}.cornerRadius = ${rRounded};
         ${rectFillCode.code}
         ${parentVar}.appendChild(el${idx});
-        ${this.genCommonNodeProps(item, `el${idx}`, parentFlex === 'none' || parentFlex === 'stack' || parentFlex === 'free')}`;
+        ${this.genLeafFillCode(rectSizing, `el${idx}`)}
+        ${this.genCommonNodeProps(item, `el${idx}`, rectParentNone)}`;
         } else if (item._type === 'ellipse') {
           // Ellipse / Circle. arc (sweep degrees) + arcStart (start degrees,
           // 0 = 3 o'clock, clockwise) + innerRadius (0–1) make rings, spinners,
           // donut and pie slices. No arc/innerRadius = a plain filled ellipse.
-          const eW = item.w || item.width || 100;
-          const eH = item.h || item.height || eW;
+          const ellParentNone = parentFlex === 'none' || parentFlex === 'stack' || parentFlex === 'free';
+          const ellSizing = resolveLeafSizing({
+            w: (item.w || item.width) || undefined, h: (item.h || item.height) || undefined,
+            defaultW: 100, defaultH: (item.w || item.width) === 'fill' ? 100 : ((item.w || item.width) || 100),
+            parentIsNone: ellParentNone,
+          });
+          const eW = ellSizing.resizeW;
+          const eH = ellSizing.resizeH;
           const eName = item.name || 'Ellipse';
           const eBg = item.bg || item.fill || null;
           const eStroke = item.stroke || null;
@@ -1679,11 +1693,17 @@ export class FigmaClient {
         ${ellStrokeCode.code}
         ${hasArc ? `try { el${idx}.arcData = { startingAngle: ${startRad}, endingAngle: ${endRad}, innerRadius: ${inner} }; } catch(e) {}` : ''}
         ${parentVar}.appendChild(el${idx});
-        ${this.genCommonNodeProps(item, `el${idx}`, parentFlex === 'none' || parentFlex === 'stack' || parentFlex === 'free')}`;
+        ${this.genLeafFillCode(ellSizing, `el${idx}`)}
+        ${this.genCommonNodeProps(item, `el${idx}`, ellParentNone)}`;
         } else if (item._type === 'image') {
           // Image placeholder (gray rectangle with image icon concept)
-          const iWidth = item.w || item.width || 200;
-          const iHeight = item.h || item.height || 150;
+          const imgParentNone = parentFlex === 'none' || parentFlex === 'stack' || parentFlex === 'free';
+          const imgSizing = resolveLeafSizing({
+            w: (item.w || item.width) || undefined, h: (item.h || item.height) || undefined,
+            defaultW: 200, defaultH: 150, parentIsNone: imgParentNone,
+          });
+          const iWidth = imgSizing.resizeW;
+          const iHeight = imgSizing.resizeH;
           const iBg = item.bg || '#f4f4f5';
           const iRounded = item.rounded || item.radius || 8;
           const iName = item.name || 'Image';
@@ -1696,7 +1716,8 @@ export class FigmaClient {
         el${idx}.cornerRadius = ${iRounded};
         ${imgFillCode.code}
         ${parentVar}.appendChild(el${idx});
-        ${this.genCommonNodeProps(item, `el${idx}`, parentFlex === 'none' || parentFlex === 'stack' || parentFlex === 'free')}`;
+        ${this.genLeafFillCode(imgSizing, `el${idx}`)}
+        ${this.genCommonNodeProps(item, `el${idx}`, imgParentNone)}`;
         } else if (item._type === 'icon') {
           const icSize = item.size || item.s || 24;
           const icBg = item.color || item.c || '#71717a';
@@ -1996,6 +2017,10 @@ export class FigmaClient {
     // Font loading with caching (shared emitter, includes __font helper)
     const fontLoadCode = this.generateFontLoadCode(collected.fonts);
 
+    // w/h="fill" on the ROOT frame: only meaningful inside an auto-layout
+    // parent, and only settable after appendChild (which runs last, below).
+    const rootFill = resolveRootFill({ fillWidth, fillHeight, hasParent: !!opts.parent, name });
+
     return `
       (async function() {
         ${fontLoadCode}
@@ -2032,8 +2057,6 @@ export class FigmaClient {
         frame.counterAxisAlignItems = '${alignVal}';
         frame.primaryAxisSizingMode = '${flex === 'col' ? (hugHeight || fillHeight || !hasExplicitHeight ? 'AUTO' : 'FIXED') : (hugWidth || fillWidth || !hasExplicitWidth ? 'AUTO' : 'FIXED')}';
         frame.counterAxisSizingMode = '${flex === 'col' ? (hugWidth || fillWidth || !hasExplicitWidth ? 'AUTO' : 'FIXED') : (hugHeight || fillHeight || !hasExplicitHeight ? 'AUTO' : 'FIXED')}';
-        ${fillWidth ? `frame.layoutSizingHorizontal = 'FILL';` : ''}
-        ${fillHeight ? `frame.layoutSizingVertical = 'FILL';` : ''}
         ${wrap && flex === 'row' && wrapGap > 0 ? `frame.counterAxisSpacing = ${wrapGap};` : ''}`}
         ${generateMinMaxCode('frame', props)}
         frame.clipsContent = ${clip};
@@ -2049,7 +2072,18 @@ export class FigmaClient {
         const __p = await figma.getNodeByIdAsync(${JSON.stringify(String(opts.parent))});
         if (!__p) throw new Error('Parent not found: ' + ${JSON.stringify(String(opts.parent))});
         if (!('appendChild' in __p)) throw new Error('Parent cannot contain children: ' + __p.type);
-        __p.appendChild(frame);` : ''}
+        __p.appendChild(frame);
+        ${rootFill.applyAfterAppend ? `
+        // w/h="fill" can only be set once the frame HAS a parent, and only if
+        // that parent uses auto-layout — hence here and not up with the other
+        // sizing props.
+        if (__p.layoutMode && __p.layoutMode !== 'NONE') {
+          ${fillWidth ? `frame.layoutSizingHorizontal = 'FILL';` : ''}
+          ${fillHeight ? `frame.layoutSizingVertical = 'FILL';` : ''}
+        } else {
+          globalThis.__layoutWarnings.push(${JSON.stringify(`"${name}" fills ${[fillWidth && 'width', fillHeight && 'height'].filter(Boolean).join(' and ')}, but the --parent frame has no auto-layout`)});
+        }` : ''}` : ''}
+        ${rootFill.warnings.map(w => `globalThis.__layoutWarnings.push(${JSON.stringify(w)});`).join('\n        ')}
 
         // Surface unresolved var: references like the batch path does, so a
         // themed render that fell back to grey is visible to the caller.
@@ -2372,6 +2406,21 @@ export class FigmaClient {
    * auto-layout), so we set x/y directly. In an auto-layout parent, position=
    * "absolute" maps to layoutPositioning='ABSOLUTE' + x/y.
    */
+  /**
+   * FILL sizing for a leaf node (Rectangle / Ellipse / Image). Mirrors what a
+   * Frame child does: emitted AFTER appendChild, because layoutSizing* only
+   * exists once the node sits in an auto-layout parent. Before this, `w="fill"`
+   * reached `resize()` as the string "fill" and the render died.
+   * @param {{fillH:boolean, fillV:boolean}} sizing from resolveLeafSizing()
+   */
+  genLeafFillCode(sizing, varName) {
+    if (!sizing || (!sizing.fillH && !sizing.fillV)) return '';
+    const parts = [];
+    if (sizing.fillH) parts.push(`${varName}.layoutSizingHorizontal = 'FILL';`, `globalThis.__figHugWarn(${varName}, 'H');`);
+    if (sizing.fillV) parts.push(`${varName}.layoutSizingVertical = 'FILL';`, `globalThis.__figHugWarn(${varName}, 'V');`);
+    return parts.join('\n        ');
+  }
+
   genCommonNodeProps(item, varName, parentIsNone) {
     const parts = [];
     if (item.opacity !== undefined && item.opacity !== null) parts.push(`${varName}.opacity = ${Number(item.opacity)};`);

--- a/src/lib/fill-sizing.js
+++ b/src/lib/fill-sizing.js
@@ -1,0 +1,63 @@
+/**
+ * Sizing keywords (`fill` / `hug`) resolved into what the generator actually
+ * has to emit. Kept pure so the rules are unit-testable without a Figma.
+ *
+ * Two callers, two shapes:
+ *   - resolveLeafSizing  — Rectangle / Ellipse / Image, which used to pass
+ *     `w="fill"` straight into `resize()` (the string reached the Plugin API).
+ *   - resolveRootFill    — the root frame of `render`, where FILL is only
+ *     meaningful once the frame sits inside an auto-layout parent.
+ */
+
+const isKeyword = (v) => v === 'fill' || v === 'hug';
+
+/**
+ * Leaf nodes (Rectangle / Ellipse / Image) have no auto-layout of their own,
+ * so sizing is only ever `resize()` plus, for a FILL axis, a
+ * `layoutSizingHorizontal/Vertical` assignment AFTER appendChild.
+ *
+ * `hug` has no meaning on a leaf — it resolves to the default like an unset
+ * axis, which is what these nodes did before the keywords existed.
+ *
+ * @param {{w?:*, h?:*, defaultW?:number, defaultH?:number, parentIsNone?:boolean}} o
+ * @returns {{resizeW:number, resizeH:number, fillH:boolean, fillV:boolean}}
+ */
+export function resolveLeafSizing({ w, h, defaultW = 100, defaultH = 100, parentIsNone = false } = {}) {
+  // A parent without auto-layout cannot be filled: fall back to the default
+  // size, exactly as a Frame child does in a flex="none" parent.
+  const fillH = w === 'fill' && !parentIsNone;
+  const fillV = h === 'fill' && !parentIsNone;
+  const numeric = (v, fallback) => (v === undefined || v === null || isKeyword(v) ? fallback : v);
+  return {
+    resizeW: numeric(w, defaultW),
+    resizeH: numeric(h, defaultH),
+    fillH,
+    fillV,
+  };
+}
+
+/**
+ * Root frame of a `render`. `w="fill"` needs two things the root only has with
+ * `--parent`: an actual parent, and one using auto-layout. Without a parent the
+ * keyword is meaningless — warn instead of emitting an assignment that throws.
+ *
+ * With a parent the assignment has to run AFTER `appendChild`, because the
+ * frame is parentless until the very end of the generated code (deliberately,
+ * so an auto-layout parent measures real content instead of the seed size).
+ *
+ * @param {{fillWidth?:boolean, fillHeight?:boolean, hasParent?:boolean, name?:string}} o
+ * @returns {{applyAfterAppend:boolean, warnings:string[]}}
+ */
+export function resolveRootFill({ fillWidth = false, fillHeight = false, hasParent = false, name = 'frame' } = {}) {
+  if (!fillWidth && !fillHeight) return { applyAfterAppend: false, warnings: [] };
+  if (hasParent) return { applyAfterAppend: true, warnings: [] };
+  const warnings = [];
+  const axes = [];
+  if (fillWidth) axes.push('width');
+  if (fillHeight) axes.push('height');
+  warnings.push(
+    `"${name}" fills ${axes.join(' and ')}, but a root frame has no auto-layout parent to fill` +
+    ` — pass --parent <id> or a fixed size`
+  );
+  return { applyAfterAppend: false, warnings };
+}

--- a/tests/fill-sizing.test.js
+++ b/tests/fill-sizing.test.js
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { resolveLeafSizing, resolveRootFill } from '../src/lib/fill-sizing.js';
+
+describe('resolveLeafSizing', () => {
+  it('keeps a numeric size and fills nothing', () => {
+    assert.deepStrictEqual(
+      resolveLeafSizing({ w: 200, h: 2 }),
+      { resizeW: 200, resizeH: 2, fillH: false, fillV: false }
+    );
+  });
+
+  it('never passes the "fill" keyword into resize()', () => {
+    const r = resolveLeafSizing({ w: 'fill', h: 2 });
+    assert.strictEqual(r.resizeW, 100);
+    assert.strictEqual(r.resizeH, 2);
+    assert.strictEqual(r.fillH, true);
+    assert.strictEqual(r.fillV, false);
+  });
+
+  it('handles fill on both axes', () => {
+    const r = resolveLeafSizing({ w: 'fill', h: 'fill', defaultW: 200, defaultH: 150 });
+    assert.deepStrictEqual(r, { resizeW: 200, resizeH: 150, fillH: true, fillV: true });
+  });
+
+  it('ignores fill in a parent without auto-layout', () => {
+    const r = resolveLeafSizing({ w: 'fill', h: 4, parentIsNone: true });
+    assert.strictEqual(r.fillH, false);
+    assert.strictEqual(r.resizeW, 100);
+  });
+
+  it('treats "hug" as unset — a leaf has nothing to hug', () => {
+    const r = resolveLeafSizing({ w: 'hug', defaultW: 42 });
+    assert.strictEqual(r.resizeW, 42);
+    assert.strictEqual(r.fillH, false);
+  });
+
+  it('falls back to the per-element defaults', () => {
+    assert.deepStrictEqual(
+      resolveLeafSizing({ defaultW: 200, defaultH: 150 }),
+      { resizeW: 200, resizeH: 150, fillH: false, fillV: false }
+    );
+  });
+});
+
+describe('resolveRootFill', () => {
+  it('is a no-op without fill', () => {
+    assert.deepStrictEqual(
+      resolveRootFill({ hasParent: true }),
+      { applyAfterAppend: false, warnings: [] }
+    );
+  });
+
+  it('defers the assignment until after appendChild when a parent exists', () => {
+    const r = resolveRootFill({ fillWidth: true, hasParent: true });
+    assert.strictEqual(r.applyAfterAppend, true);
+    assert.deepStrictEqual(r.warnings, []);
+  });
+
+  it('warns instead of throwing when there is no parent', () => {
+    const r = resolveRootFill({ fillWidth: true, hasParent: false, name: 'A' });
+    assert.strictEqual(r.applyAfterAppend, false);
+    assert.strictEqual(r.warnings.length, 1);
+    assert.match(r.warnings[0], /^"A" fills width/);
+    assert.match(r.warnings[0], /--parent/);
+  });
+
+  it('names both axes in one warning', () => {
+    const r = resolveRootFill({ fillWidth: true, fillHeight: true, name: 'B' });
+    assert.match(r.warnings[0], /fills width and height/);
+  });
+});

--- a/tests/flex-none.test.js
+++ b/tests/flex-none.test.js
@@ -27,7 +27,7 @@ describe('flex="none" z-stack', () => {
     // first literal 'NONE' anywhere in the file also caught the runtime prelude,
     // which legitimately mentions primaryAxisSizingMode while inspecting a
     // node's PARENT — a false failure about code that isn't the frame's.
-    const start = code.indexOf('const frame = figma.createFrame');
+    const start = code.indexOf('frame = figma.createFrame');
     assert.ok(start > -1, 'root frame block not found');
     const frameStmts = code
       .slice(start)

--- a/tests/render-fill-errors.test.js
+++ b/tests/render-fill-errors.test.js
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { FigmaClient } from '../src/figma-client.js';
+
+function assertValidJs(code) {
+  assert.doesNotThrow(() => new Function(code), SyntaxError, `bad JS:\n${code}`);
+}
+
+const client = new FigmaClient();
+
+// Every failure inside the generated render code used to surface as
+// "ReferenceError: frame is not defined": the catch block read a `const frame`
+// declared inside the try. The real error never reached the caller and
+// frame.remove() never ran, so a failed render left an orphan on the canvas.
+describe('render error handling is not self-masking', () => {
+  it('declares frame outside the try so the catch can see it', async () => {
+    const code = await client.parseJSX('<Frame name="A" w={100} h={40} bg="#eee" />');
+    assert.ok(/let frame;/.test(code), code);
+    assert.ok(!/const frame = figma\.createFrame\(\)/.test(code), code);
+    assert.ok(/frame = figma\.createFrame\(\)/.test(code), code);
+    assertValidJs(code);
+  });
+
+  it('guards the cleanup so a failing remove() cannot replace the real error', async () => {
+    const code = await client.parseJSX('<Frame name="A" w={100} h={40} bg="#eee" />');
+    const tail = code.slice(code.indexOf('catch(e)'));
+    assert.ok(/if \(frame\)/.test(tail), tail);
+    assert.ok(/\[Node: /.test(tail), tail);
+  });
+});
+
+// w/h="fill" needs an auto-layout PARENT. The root frame is parentless until
+// the very end of the generated code, so a FILL assignment near the top could
+// never work — and without --parent there is nothing to fill at all.
+describe('fill sizing on the root frame', () => {
+  it('warns instead of throwing when there is no --parent', async () => {
+    const code = await client.parseJSX('<Frame name="A" w="fill" h={40} bg="#eee" />');
+    assert.ok(!/frame\.layoutSizingHorizontal/.test(code), code);
+    assert.ok(/__layoutWarnings\.push\("\\"A\\" fills width/.test(code), code);
+    assertValidJs(code);
+  });
+
+  it('sets FILL after appendChild when --parent is given', async () => {
+    const code = await client.parseJSX(
+      '<Frame name="B" w="fill" h={20} bg="#0f0" />', { parent: '1:2' }
+    );
+    const iAppend = code.indexOf('__p.appendChild(frame)');
+    const iFill = code.indexOf("frame.layoutSizingHorizontal = 'FILL'");
+    assert.ok(iAppend > 0 && iFill > 0, code);
+    assert.ok(iFill > iAppend, 'FILL must be assigned after appendChild');
+    assertValidJs(code);
+  });
+
+  it('checks the parent actually uses auto-layout', async () => {
+    const code = await client.parseJSX('<Frame name="B" h="fill" w={20} />', { parent: '1:2' });
+    assert.ok(/__p\.layoutMode && __p\.layoutMode !== 'NONE'/.test(code), code);
+    assert.ok(/frame\.layoutSizingVertical = 'FILL'/.test(code), code);
+    assertValidJs(code);
+  });
+});
+
+// Rectangle / Ellipse / Image passed item.w straight into resize(), so
+// w="fill" arrived at the Plugin API as the string "fill".
+describe('fill sizing on leaf nodes', () => {
+  const cases = [
+    ['Rectangle', '<Frame name="C" w={200} h={60} flex="col"><Rectangle w="fill" h={2} bg="#f00" /></Frame>'],
+    ['Ellipse', '<Frame name="C" w={200} h={60} flex="col"><Ellipse w="fill" h={20} bg="#f00" /></Frame>'],
+    ['Image', '<Frame name="C" w={200} h={60} flex="col"><Image w="fill" h={20} /></Frame>'],
+  ];
+
+  for (const [label, jsx] of cases) {
+    it(`${label}: keeps "fill" out of resize() and sets FILL after appendChild`, async () => {
+      const code = await client.parseJSX(jsx);
+      assert.ok(!/resize\((["'])?fill/.test(code), code);
+      const iAppend = code.indexOf('.appendChild(el0)');
+      const iFill = code.indexOf("el0.layoutSizingHorizontal = 'FILL'");
+      assert.ok(iAppend > 0 && iFill > iAppend, code);
+      assert.ok(/__figHugWarn\(el0, 'H'\)/.test(code), code);
+      assertValidJs(code);
+    });
+  }
+
+  it('ignores fill in a flex="none" parent instead of emitting an assignment that throws', async () => {
+    const code = await client.parseJSX('<Frame name="C" w={200} h={60} flex="none"><Rectangle w="fill" h={2} bg="#f00" /></Frame>');
+    assert.ok(!/el0\.layoutSizingHorizontal/.test(code), code);
+    assert.ok(/el0\.resize\(100, 2\)/.test(code), code);
+    assertValidJs(code);
+  });
+
+  it('fills both axes when asked', async () => {
+    const code = await client.parseJSX('<Frame name="C" w={200} h={60} flex="col"><Rectangle w="fill" h="fill" bg="#f00" /></Frame>');
+    assert.ok(/el0\.layoutSizingHorizontal = 'FILL'/.test(code), code);
+    assert.ok(/el0\.layoutSizingVertical = 'FILL'/.test(code), code);
+    assertValidJs(code);
+  });
+
+  it('leaves fixed sizes untouched', async () => {
+    const code = await client.parseJSX('<Frame name="F" w={200} h={60} flex="col"><Rectangle w={100} h={2} bg="#f00" /></Frame>');
+    assert.ok(/el0\.resize\(100, 2\)/.test(code), code);
+    assert.ok(!/el0\.layoutSizing/.test(code), code);
+  });
+
+  // render-batch shares the child generator, so the leaf fix has to hold there too.
+  it('applies in the render-batch path as well', async () => {
+    const code = await client.parseJSXBatch([
+      '<Frame name="C" w={200} h={60} flex="col"><Rectangle w="fill" h={2} bg="#f00" /></Frame>',
+    ]);
+    assert.ok(!/resize\((["'])?fill/.test(code), code);
+    assert.ok(/layoutSizingHorizontal = 'FILL'/.test(code), code);
+    assertValidJs(code);
+  });
+});


### PR DESCRIPTION
Fixes #42.

Two commits, reviewable independently.

### 1. The `catch` block masked every render error

The generated root-frame code declared `const frame` inside the `try` and called `frame.remove()` from the `catch`, where that binding is not in scope. So every failure — bad prop, unsupported sizing keyword, missing parent — surfaced as `ReferenceError: frame is not defined`, and the `[Node: …] <message>` wrapper right below it was unreachable. `frame.remove()` never ran either, so a failed render left an orphan frame on the canvas.

`let frame` is now hoisted out of the `try` and the cleanup is guarded, so neither a throwing `createFrame()` nor a failing `remove()` can replace the original error.

Before / after, same command:

```
$ figma-cli render '<Frame name="E" w={50} h={50} bg="#fff" />' --parent 999:9999
✗ Render failed: ReferenceError: frame is not defined     # before
✗ Render failed at E:  Error: Parent not found: 999:9999   # after
```

…and no orphan node left behind in the second case.

### 2. The three `fill` bugs the masking hid

- **Root frame with `--parent`.** `frame.layoutSizingHorizontal = 'FILL'` was emitted near the top of the template, but `__p.appendChild(frame)` runs at the very end (deliberately, so an auto-layout parent measures real content rather than the seed size). FILL was set while the frame was still parentless, which Figma rejects — it could never have worked. The assignment now runs after `appendChild`, guarded by a check that the parent actually uses auto-layout (with a layout warning if it does not).
- **Root frame without `--parent`.** Nothing to fill. Emits a warning through the existing `__layoutWarnings` channel instead of throwing.
- **`<Rectangle>` / `<Ellipse>` / `<Image>`.** These passed `item.w` straight into `resize()`, so `w="fill"` reached the Plugin API as the string `"fill"`. They now follow the same shape as a Frame child: the keyword is kept out of `resize()`, and `layoutSizing*` plus `__figHugWarn` are emitted after `appendChild`. In a `flex="none"` parent the keyword is ignored rather than emitted, matching Frame children.

The decision logic sits in `src/lib/fill-sizing.js` as two pure functions (`resolveLeafSizing`, `resolveRootFill`) with unit tests, per the convention `browserDebugArgs` / `src/platform.js` established.

### Tests

`tests/render-fill-errors.test.js` asserts on the generated code for every reproduction case in #42, including the `render-batch` path (it shares the child generator, so the leaf fix lands there too). `tests/flex-none.test.js` needed a one-word anchor update (`const frame = figma.createFrame` → `frame = figma.createFrame`).

543 tests pass, no Figma required.

Verified live against Figma Desktop (Yolo Mode, macOS):

```
w="fill" child in a 300px parent with p={8}   → width 284, layoutSizingHorizontal FILL
<Rectangle w="fill" h={2}/> in a 200px frame  → width 200, FILL, type RECTANGLE
root w="fill" without --parent                → renders, one clear warning
--parent with an unknown id                   → "Parent not found: …", no orphan
```

### Out of scope

`generateBatchCode` has no `try/catch` at all — no masking there, but also no cleanup when a batch render fails midway. Left alone deliberately; happy to look at it separately if you want it.
