### PR TITLE
feat(render): bind text to the file's text styles (textStyle=)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,32 @@ figma-cli set fill "var:primary"
 
 ---
 
+## Text Styles (textStyle= syntax)
+
+Colors bind through `var:`; typography binds through the file's **text styles**. A `<Text>` that names none is an island of hardcoded values — a style update in the file will never reach it, and `figma-cli analyze` reports it as missing a style.
+
+```bash
+figma-cli styles          # what this file has: name, family, weight, size
+```
+
+```jsx
+<Text textStyle="Heading/H1">Title</Text>
+<Text textStyle="H1">Title</Text>              // the part after the last "/" works too
+<Text textStyle="Body/M" color="var:foreground">Copy</Text>
+```
+
+**Without `textStyle=`, the style is matched automatically** — but only when exactly one style shares this text's font size and weight. Several matches or none: nothing is applied and the render says why. `--no-auto-style` turns the matching off; `textStyle=` keeps working either way.
+
+The font family only has to match when you wrote `font=` yourself. `<Text size={36} weight="bold">` therefore finds a 36px Bold style in any family — the default "Inter" is a fallback, not a choice.
+
+**The style wins over explicit typography props, and that is not a choice.** Writing `fontSize`, `fontName`, `lineHeight` or `letterSpacing` onto a styled text node CLEARS `textStyleId` in Figma — an "override" would detach the style it overrides. So `<Text textStyle="Body/M" size={20}>` keeps `Body/M`, ignores the size, and says so. Want the other size? Use the style that has it, or drop `textStyle=`. `align` is unaffected (it is not part of a text style) and still applies.
+
+Rich text with per-range formatting (`<b>`, `<i>`, per-run props) is skipped by the automatic matching — mixed typography is deliberate.
+
+Library (remote) styles resolve by name too, as long as the document already uses them somewhere — Figma exposes remote styles by key only, so styles nobody has used yet are invisible to any plugin.
+
+---
+
 ## Connection Modes
 
 **Yolo Mode (Recommended):** `figma-cli connect` - Patches Figma Desktop once, fully automatic.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -164,6 +164,15 @@ node src/index.js node to-component "1:234"    # Convert to component
 node src/index.js node delete "1:234"          # Delete by ID
 ```
 
+## Text Styles
+
+```bash
+node src/index.js styles                       # List the file's text styles
+node src/index.js styles --json                # Same, machine-readable
+```
+
+Use the names in JSX: `<Text textStyle="Heading/H1">`. The tail of a slash-grouped name works too (`textStyle="H1"`). A `<Text>` without `textStyle=` gets a style automatically when exactly one matches its size and weight — `render --no-auto-style` disables that. The style wins over `size`/`weight`/`font`/`lineHeight`/`letterSpacing`: writing those onto a styled node clears `textStyleId` in Figma, so conflicting props are reported instead of applied. `align` is not part of a text style and still applies.
+
 ## Slots
 
 Figma's native slots feature for flexible content areas in components.

--- a/src/commands/render.js
+++ b/src/commands/render.js
@@ -62,6 +62,30 @@ function printLayoutWarnings(warnings) {
   console.log(chalk.gray('  Fix: give the parent a fixed size on that axis, or drop the fill from the child.'));
 }
 
+/**
+ * Report which text styles the render bound, and which it could not.
+ *
+ * Without this the whole feature is invisible: a text that silently kept its
+ * hardcoded 14px Inter looks exactly like one that picked up "Body/S".
+ */
+function printTextStyles(textStyles) {
+  if (!textStyles) return;
+  const applied = textStyles.applied || [];
+  const warnings = textStyles.warnings || [];
+  if (applied.length > 0) {
+    const counts = new Map();
+    for (const n of applied) counts.set(n, (counts.get(n) || 0) + 1);
+    const summary = [...counts.entries()]
+      .map(([n, c]) => (c > 1 ? `${n} ×${c}` : n)).join(', ');
+    console.log(chalk.gray(`  text styles: ${summary}`));
+  }
+  if (warnings.length > 0) {
+    console.log(chalk.yellow(`\n⚠ ${warnings.length} text style issue(s):`));
+    for (const w of warnings) console.log(chalk.yellow('  ' + w));
+    console.log(chalk.gray('  `figma-cli styles` lists what this file has.'));
+  }
+}
+
 // Remember what the last render created so `figma-cli undo` can remove
 // exactly those nodes. CLI-side state file: covers every render path
 // (eval-based, daemon render, render-batch) and survives daemon restarts.
@@ -147,6 +171,7 @@ program
   .option('--keep-wrapper', 'Keep an outer flex Frame as a parent — disables the auto-split that turns "N items in a flex wrapper" into independent canvas items')
   .option('-c, --collection <name>', 'Pin var:<name> resolution to this variable collection (case-insensitive, fuzzy match). Per-attr `var:collection:name` overrides this.')
   .option('--verify', 'After rendering, return a screenshot of the result (saves PNG, prints JSON) — replaces a separate `figma-cli verify` roundtrip')
+  .option('--no-auto-style', "Don't auto-apply a matching text style to <Text> that names none (textStyle= still works)")
   .action(async (rawJsx, options) => {
     const jsx = unescapeShell(rawJsx);
     warnUnknownProps([jsx]);
@@ -215,6 +240,7 @@ program
       const { FigmaClient } = await import('../figma-client.js');
       const client = new FigmaClient();
       if (options.collection) client.setCollection(options.collection);
+      if (options.autoStyle === false) client.setAutoTextStyle(false);
       const code = await client.parseJSX(jsx, {
         x: posX,
         y: options.y !== undefined ? posY : undefined,
@@ -229,6 +255,7 @@ program
       if (result.name) console.log(chalk.gray('  name: ' + result.name));
       printUnresolvedVars(result.unresolved);
       printLayoutWarnings(result.layoutWarnings);
+      printTextStyles(result.textStyles);
       recordCreated([result]);
 
       await maybeAsComponent(result.id);
@@ -262,6 +289,7 @@ program
   .option('--as-component', 'After rendering, convert each resulting frame to a Figma component')
   .option('-c, --collection <name>', 'Pin var:<name> resolution to this variable collection (case-insensitive, fuzzy match). Per-attr `var:collection:name` overrides this.')
   .option('--verify', 'After rendering, return a screenshot of each result (saves PNGs, prints JSON)')
+  .option('--no-auto-style', "Don't auto-apply a matching text style to <Text> that names none (textStyle= still works)")
   .action(async (jsxArrayStr, options) => {
     await checkConnection();
     try {
@@ -280,13 +308,16 @@ program
         gap,
         vertical,
         collection: options.collection || undefined,
+        autoStyle: options.autoStyle === false ? false : undefined,
       });
       // Unwrap the wrapped form returned when there are warnings to report.
       let unresolvedVars = null;
       let layoutWarnings = null;
+      let textStyles = null;
       if (results && !Array.isArray(results) && Array.isArray(results.frames)) {
         unresolvedVars = results.unresolved;
         layoutWarnings = results.layoutWarnings;
+        textStyles = results.textStyles;
         results = results.frames;
       }
 
@@ -298,6 +329,7 @@ program
         recordCreated(results);
         printUnresolvedVars(unresolvedVars);
         printLayoutWarnings(layoutWarnings);
+        printTextStyles(textStyles);
 
         if (options.asComponent) {
           const ids = results.map(r => r.id).filter(Boolean);

--- a/src/commands/styles.js
+++ b/src/commands/styles.js
@@ -1,0 +1,74 @@
+// Commands: styles — what an agent has to read before it can use textStyle=
+import chalk from 'chalk';
+import {
+  program,
+  checkConnection,
+  fastEval
+} from '../lib/cli-core.js';
+
+// ============ STYLE COMMANDS ============
+
+// Local styles plus the remote (library) styles the document already uses.
+// Remote styles have no name-addressable lookup in the Plugin API, so the ones
+// in use are the only ones anybody can reference — same set the renderer
+// resolves `textStyle=` against.
+const LIST_TEXT_STYLES = `(async () => {
+  const local = await figma.getLocalTextStylesAsync();
+  const out = local.map(s => ({
+    name: s.name, family: s.fontName.family, weight: s.fontName.style,
+    size: s.fontSize, remote: false,
+  }));
+  const known = new Set(local.map(s => s.id));
+  try {
+    const texts = figma.currentPage.findAllWithCriteria({ types: ['TEXT'] });
+    const ids = new Set();
+    for (const t of texts) {
+      const id = t.textStyleId;
+      if (typeof id === 'string' && id && !known.has(id)) ids.add(id);
+    }
+    for (const id of ids) {
+      const st = await figma.getStyleByIdAsync(id);
+      if (st && st.fontName) {
+        out.push({
+          name: st.name, family: st.fontName.family, weight: st.fontName.style,
+          size: st.fontSize, remote: true,
+        });
+      }
+    }
+  } catch (e) {}
+  return out;
+})()`;
+
+program
+  .command('styles')
+  .description('List the text styles of the current file (use the names with textStyle= in JSX)')
+  .option('--json', 'Raw JSON output')
+  .action(async (options) => {
+    await checkConnection();
+
+    const styles = await fastEval(LIST_TEXT_STYLES);
+    const list = Array.isArray(styles) ? styles : [];
+
+    if (options.json) {
+      console.log(JSON.stringify(list, null, 2));
+      return;
+    }
+
+    if (list.length === 0) {
+      console.log(chalk.yellow('No text styles in this file.'));
+      console.log(chalk.gray('Rendered text keeps its own font/size props — nothing to bind to.'));
+      return;
+    }
+
+    const width = Math.max(...list.map(s => s.name.length));
+    for (const s of list) {
+      const meta = `${s.family} ${s.weight} ${s.size}px`;
+      console.log(
+        chalk.cyan(s.name.padEnd(width)) + '  ' +
+        chalk.gray(meta) + (s.remote ? chalk.gray(' (library)') : '')
+      );
+    }
+    console.log(chalk.gray(`\n${list.length} text styles. Use them as `) +
+      chalk.white('<Text textStyle="' + list[0].name + '">') +
+      chalk.gray(' — the part after the last "/" works too.'));
+  });

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -399,7 +399,7 @@ async function handleRequest(req, res) {
 
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         try {
-          const { action, code, jsx, jsxArray, gap, vertical, collection } = payload;
+          const { action, code, jsx, jsxArray, gap, vertical, collection, autoStyle } = payload;
           let result;
 
           const execWithTimeout = async (fn, timeoutMs = 30000) => {
@@ -428,6 +428,7 @@ async function handleRequest(req, res) {
               const ClientClass = await getFigmaClient();
               const batchParser = new ClientClass();
               if (collection) batchParser.setCollection(collection);
+              if (autoStyle === false) batchParser.setAutoTextStyle(false);
               const batchCode = await batchParser.parseJSXBatch(jsxArray, {
                 gap: gap || 40,
                 vertical: vertical || false

--- a/src/figma-client.js
+++ b/src/figma-client.js
@@ -7,6 +7,7 @@
 
 import WebSocket from 'ws';
 import { getCdpPort } from './figma-patch.js';
+import { normalizeWeight, buildStyleIndex, matchTextStyle } from './lib/text-styles.js';
 
 /**
  * Visible fallback colors for shadcn semantic token names (Zinc light theme).
@@ -142,6 +143,141 @@ export const LAYOUT_WARN_PRELUDE = `
           };
         }`;
 
+/**
+ * Runtime prelude: resolve and apply the file's TEXT STYLES.
+ *
+ * Without this every rendered text is an island of hardcoded values — it never
+ * picks up a style, and `figma-cli analyze` flags it as "missing style".
+ *
+ * The matching rules are not written here. `src/lib/text-styles.js` owns them,
+ * and its source is embedded below, so the unit tests exercise exactly the code
+ * that runs inside Figma.
+ *
+ * The cache holds local styles PLUS every remote (library) style already used
+ * by a text node on the page — a library style has no other name-addressable
+ * route, since Figma only exposes remote styles by key.
+ */
+export const TEXT_STYLE_PRELUDE = `
+        {
+          ${normalizeWeight.toString()}
+          ${buildStyleIndex.toString()}
+          ${matchTextStyle.toString()}
+
+          globalThis.__textStyleWarnings = [];
+          globalThis.__textStyleApplied = [];
+
+          globalThis.__loadTextStyles = async () => {
+            if (globalThis.__textStyleCache &&
+                Date.now() - (globalThis.__textStyleCacheTime || 0) < 30000) {
+              return globalThis.__textStyleCache;
+            }
+            const local = await figma.getLocalTextStylesAsync();
+            const styles = local.map(s => ({
+              id: s.id, name: s.name, fontSize: s.fontSize,
+              fontName: { family: s.fontName.family, style: s.fontName.style },
+            }));
+            const known = new Set(styles.map(s => s.id));
+            // Remote styles are only reachable by key, so harvest the ones the
+            // document already uses — that is what a designer means by "the
+            // styles in this file".
+            try {
+              const texts = figma.currentPage.findAllWithCriteria({ types: ['TEXT'] });
+              const ids = new Set();
+              for (const t of texts) {
+                const id = t.textStyleId;
+                if (typeof id === 'string' && id && !known.has(id)) ids.add(id);
+              }
+              for (const id of ids) {
+                const st = await figma.getStyleByIdAsync(id);
+                if (st && st.fontName) {
+                  styles.push({
+                    id: st.id, name: st.name, fontSize: st.fontSize,
+                    fontName: { family: st.fontName.family, style: st.fontName.style },
+                    remote: true,
+                  });
+                }
+              }
+            } catch (e) {}
+            globalThis.__textStyleCache = { styles, index: buildStyleIndex(styles) };
+            globalThis.__textStyleCacheTime = Date.now();
+            return globalThis.__textStyleCache;
+          };
+
+          const __setStyle = async (node, style) => {
+            await figma.loadFontAsync(style.fontName);
+            await node.setTextStyleIdAsync(style.id);
+            globalThis.__textStyleApplied.push(style.name);
+          };
+
+          // Explicit textStyle="…". Never throws: an unknown name is a warning
+          // and the text still renders with its own props.
+          globalThis.__applyTextStyle = async (node, name, explicit) => {
+            try {
+              const cache = await globalThis.__loadTextStyles();
+              const style = cache.index[name];
+              if (!style) {
+                const available = Object.keys(cache.index).filter(n => n.indexOf('/') >= 0);
+                globalThis.__textStyleWarnings.push(
+                  'text style "' + name + '" not found' +
+                  (available.length ? ' — available: ' + available.slice(0, 8).join(', ') : ' (this file has none)')
+                );
+                return;
+              }
+              await __setStyle(node, style);
+              // A typographic prop written after the style would clear it, so
+              // the conflicting props are reported rather than applied.
+              const e = explicit || {};
+              const clashes = [];
+              if (e.size !== undefined && Number(e.size) !== Number(style.fontSize)) {
+                clashes.push('size={' + e.size + '} vs ' + style.fontSize + 'px');
+              }
+              if (e.weightStyle && normalizeWeight(e.weightStyle) !== normalizeWeight(style.fontName.style)) {
+                clashes.push('weight "' + e.weightStyle + '" vs ' + style.fontName.style);
+              }
+              if (e.family && e.family.toLowerCase() !== style.fontName.family.toLowerCase()) {
+                clashes.push('font "' + e.family + '" vs ' + style.fontName.family);
+              }
+              if (e.lineHeight) clashes.push('lineHeight');
+              if (e.letterSpacing) clashes.push('letterSpacing');
+              if (clashes.length) {
+                globalThis.__textStyleWarnings.push(
+                  'textStyle="' + style.name + '" wins over ' + clashes.join(', ') +
+                  ' — writing those would detach the style, so they were dropped'
+                );
+              }
+            } catch (e) {
+              globalThis.__textStyleWarnings.push('text style "' + name + '" failed: ' + e.message);
+            }
+          };
+
+          // No textStyle given: apply the file's style when EXACTLY one matches
+          // this text's size and weight. Several matches or none = do nothing
+          // and say why; guessing would restyle text that was sized on purpose.
+          globalThis.__autoTextStyle = async (node, want) => {
+            try {
+              const cache = await globalThis.__loadTextStyles();
+              if (!cache.styles.length) return;
+              const r = matchTextStyle({
+                styles: cache.styles, size: want.size, weightStyle: want.weightStyle,
+                family: want.family, familyExplicit: want.familyExplicit,
+              });
+              if (r.match) { await __setStyle(node, r.match); return; }
+              const label = want.size + 'px ' + want.weightStyle;
+              if (r.ambiguous) {
+                globalThis.__textStyleWarnings.push(
+                  'no style applied for ' + label + ' — ' + r.ambiguous.length +
+                  ' styles match: ' + r.ambiguous.join(', ') + ' (name one with textStyle=)'
+                );
+              } else if (r.nearest) {
+                globalThis.__textStyleWarnings.push(
+                  'no text style for ' + label + ' — nearest: "' + r.nearest.name + '" (' +
+                  r.nearest.fontSize + 'px ' + r.nearest.fontName.style + ')'
+                );
+              }
+            } catch (e) {}
+          };
+        }`;
+
 export function generateMinMaxCode(varName, item = {}) {
   const num = (v) => {
     if (v === undefined || v === null || v === '') return null;
@@ -174,11 +310,19 @@ export class FigmaClient {
     // in JSX overrides this. nullish = use the global "shadcn first, then any"
     // fallback in the var-cache loader.
     this.collectionFilter = null;
+    // Auto-apply a file text style to a <Text> that names none, when exactly
+    // one style matches its size and weight. `--no-auto-style` turns it off.
+    this.autoTextStyle = true;
   }
 
   /** Pin variable lookups to a specific collection (by case-insensitive name match). */
   setCollection(name) {
     this.collectionFilter = name || null;
+  }
+
+  /** Turn the automatic text-style matching on or off (JSX `textStyle=` still applies). */
+  setAutoTextStyle(on) {
+    this.autoTextStyle = on !== false;
   }
 
   /**
@@ -605,6 +749,7 @@ export class FigmaClient {
     ` : '';
 
     // Generate code for each frame
+    let anyText = false;
     const framesCodes = parsed.map(({ props, children }, frameIdx) => {
       const name = props.name || 'Frame';
       // "fill" / "hug" are sizing keywords that only make sense for nested
@@ -648,7 +793,8 @@ export class FigmaClient {
       const effectsCode = this.generateEffectsCode(props, `f${frameIdx}`);
       const imageCode = props.image ? this.generateImageFillCode(props.image, `f${frameIdx}`, props.imageScale) : '';
 
-      const childCode = this.generateChildrenCode(children, `f${frameIdx}`, flex, { counter: { value: 0 }, prefix: `${frameIdx}_`, iconSvgMap });
+      const childCode = this.generateChildrenCode(children, `f${frameIdx}`, flex, { counter: { value: 0 }, prefix: `${frameIdx}_`, iconSvgMap, autoTextStyle: this.autoTextStyle });
+      if (this.hasTextItems(children)) anyText = true;
 
       return `
         const f${frameIdx} = figma.createFrame();
@@ -682,10 +828,14 @@ export class FigmaClient {
       `;
     }).join('\n');
 
+    // Text styles cost a style query, so only pay for it when there is text.
+    const textStylePrelude = anyText ? TEXT_STYLE_PRELUDE : '';
+
     return `
       (async function() {
         ${fontLoads}
         ${LAYOUT_WARN_PRELUDE}
+        ${textStylePrelude}
         ${varLoadCode}
 
         // Calculate start position
@@ -713,8 +863,15 @@ export class FigmaClient {
         if (globalThis.__figHugFlush) globalThis.__figHugFlush();
         const layoutWarnings = globalThis.__layoutWarnings || [];
         globalThis.__layoutWarnings = [];
-        return (unresolved.length > 0 || layoutWarnings.length > 0)
-          ? { frames: results, unresolved, layoutWarnings }
+        const textStyles = {
+          applied: globalThis.__textStyleApplied || [],
+          warnings: globalThis.__textStyleWarnings || [],
+        };
+        globalThis.__textStyleApplied = [];
+        globalThis.__textStyleWarnings = [];
+        return (unresolved.length > 0 || layoutWarnings.length > 0 ||
+                textStyles.applied.length > 0 || textStyles.warnings.length > 0)
+          ? { frames: results, unresolved, layoutWarnings, textStyles }
           : results;
       })()
     `;
@@ -866,7 +1023,8 @@ export class FigmaClient {
     const known = {
       Frame: [...layout, ...paint, ...corners, ...effects],
       Text: ['name', 'size', 'weight', 'color', 'font', 'italic', 'align', 'w', 'h', 'width', 'height',
-        'grow', 'opacity', 'x', 'y', 'position', 'lineHeight', 'letterSpacing', 'truncate', 'maxLines'],
+        'grow', 'opacity', 'x', 'y', 'position', 'lineHeight', 'letterSpacing', 'truncate', 'maxLines',
+        'textStyle'],
       Icon: ['name', 'size', 's', 'color', 'c', 'x', 'y', 'position'],
       Rect: ['name', 'w', 'h', 'width', 'height', 'bg', 'fill', 'rounded', 'radius', 'opacity', 'x', 'y', 'position'],
       Rectangle: null, // alias of Rect, filled below
@@ -887,6 +1045,7 @@ export class FigmaClient {
       background: 'bg', backgroundColor: 'bg',
       border: 'stroke', borderColor: 'stroke', borderWidth: 'strokeWidth',
       fontSize: 'size', fontWeight: 'weight', fontFamily: 'font', textAlign: 'align',
+      style: 'textStyle', typography: 'textStyle', textstyle: 'textStyle',
       spacing: 'gap', itemSpacing: 'gap',
       alignItems: 'items', justifyContent: 'justify',
       visibility: 'visible',
@@ -1301,6 +1460,18 @@ export class FigmaClient {
   }
 
   /**
+   * Does this tree contain any <Text>? Decides whether the text-style prelude
+   * (which queries the file's styles) is worth emitting at all.
+   */
+  hasTextItems(items) {
+    for (const item of items || []) {
+      if (item._type === 'text') return true;
+      if (item._children && this.hasTextItems(item._children)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Generate Plugin API code for a list of parsed child elements.
    * Shared by the single-render path (generateCode) and the batch path
    * (parseJSXBatch) so both support the same child types and props.
@@ -1335,6 +1506,41 @@ export class FigmaClient {
           const tLetterSpacing = item.letterSpacing !== undefined ? dimUnit(item.letterSpacing) : null;
           const tTruncate = item.truncate === true || item.truncate === 'true';
           const tMaxLines = item.maxLines !== undefined ? parseInt(item.maxLines) : null;
+
+          // Text styles. `textStyle="Heading/H1"` names one explicitly; without
+          // it the file's styles are matched against this text's size + weight
+          // (see TEXT_STYLE_PRELUDE). Applied after `characters`, so the style
+          // wins over the raw props written above it.
+          //
+          // Nothing typographic may be written AFTERWARDS: measured against a
+          // live Figma, assigning fontSize / fontName / lineHeight /
+          // letterSpacing silently CLEARS textStyleId. A "CSS-style override"
+          // would therefore detach the very style it was overriding. Explicit
+          // props that disagree with the style are reported instead — the
+          // caller drops one of the two. textAlignHorizontal is safe (it is not
+          // part of a text style) and is the one thing still applied after.
+          const textStyleName = item.textStyle || item.textstyle || null;
+          // Rich text with per-range formatting is deliberate mixed typography;
+          // auto-matching a single style onto it would fight the ranges.
+          const hasStyledRuns = (item._runs || []).some(r => r.style && Object.keys(r.style).length);
+          const autoStyle = ctx.autoTextStyle !== false && !textStyleName && !hasStyledRuns;
+          const explicitTypography = {};
+          if (item.size !== undefined) explicitTypography.size = Number(size);
+          if (item.font !== undefined) explicitTypography.family = family;
+          if (item.weight !== undefined || item.italic !== undefined) explicitTypography.weightStyle = style;
+          if (item.lineHeight !== undefined) explicitTypography.lineHeight = true;
+          if (item.letterSpacing !== undefined) explicitTypography.letterSpacing = true;
+          const styleApplyCode = textStyleName
+            ? `await globalThis.__applyTextStyle(el${idx}, ${JSON.stringify(String(textStyleName))}, ${JSON.stringify(explicitTypography)});`
+            : autoStyle
+              ? `await globalThis.__autoTextStyle(el${idx}, ${JSON.stringify({
+                  size: Number(size), weightStyle: style, family,
+                  familyExplicit: item.font !== undefined,
+                })});`
+              : '';
+          const styleOverrideCode = styleApplyCode && tAlign
+            ? `el${idx}.textAlignHorizontal = '${tAlign}';`
+            : '';
 
           const runStyleCode = (item._runs || [])
             .filter(r => r.style && Object.keys(r.style).length)
@@ -1378,6 +1584,8 @@ export class FigmaClient {
         ${tLetterSpacing ? `try { el${idx}.letterSpacing = ${tLetterSpacing}; } catch(e) {}` : ''}
         ${tAlign ? `el${idx}.textAlignHorizontal = '${tAlign}';` : ''}
         el${idx}.characters = ${JSON.stringify(item.content)};
+        ${styleApplyCode}
+        ${styleOverrideCode}
         ${textFillCode.code}
         ${runStyleCode ? runStyleCode : ''}
         ${parentVar}.appendChild(el${idx});
@@ -1885,7 +2093,7 @@ export class FigmaClient {
     const collected = this.collectFontsAndVarUsage(children);
     if (collected.usesVars) usesVars = true;
 
-    const childCode = this.generateChildrenCode(children, 'frame', flex, { counter: { value: 0 }, prefix: '', iconSvgMap });
+    const childCode = this.generateChildrenCode(children, 'frame', flex, { counter: { value: 0 }, prefix: '', iconSvgMap, autoTextStyle: this.autoTextStyle });
 
     const { alignVal, justifyVal } = resolveAlign(flex, props);
 
@@ -1996,10 +2204,14 @@ export class FigmaClient {
     // Font loading with caching (shared emitter, includes __font helper)
     const fontLoadCode = this.generateFontLoadCode(collected.fonts);
 
+    // Text styles cost a style query, so only pay for it when there is text.
+    const textStylePrelude = this.hasTextItems(children) ? TEXT_STYLE_PRELUDE : '';
+
     return `
       (async function() {
         ${fontLoadCode}
         ${LAYOUT_WARN_PRELUDE}
+        ${textStylePrelude}
         ${varLoadCode}
         ${smartPosCode}
 
@@ -2054,8 +2266,15 @@ export class FigmaClient {
         if (globalThis.__figHugFlush) globalThis.__figHugFlush();
         const __layoutWarnings = globalThis.__layoutWarnings || [];
         globalThis.__layoutWarnings = [];
-        return (__unresolved.length > 0 || __layoutWarnings.length > 0)
-          ? { id: frame.id, name: frame.name, unresolved: __unresolved, layoutWarnings: __layoutWarnings }
+        const __textStyles = {
+          applied: globalThis.__textStyleApplied || [],
+          warnings: globalThis.__textStyleWarnings || [],
+        };
+        globalThis.__textStyleApplied = [];
+        globalThis.__textStyleWarnings = [];
+        return (__unresolved.length > 0 || __layoutWarnings.length > 0 ||
+                __textStyles.applied.length > 0 || __textStyles.warnings.length > 0)
+          ? { id: frame.id, name: frame.name, unresolved: __unresolved, layoutWarnings: __layoutWarnings, textStyles: __textStyles }
           : { id: frame.id, name: frame.name };
         } catch(e) {
           frame.remove();
@@ -3276,10 +3495,12 @@ export class FigmaClient {
         };
 
         // Get local styles that reference library
-        const paintStyles = figma.getLocalPaintStyles();
-        const textStyles = figma.getLocalTextStyles();
-        const effectStyles = figma.getLocalEffectStyles();
-        const gridStyles = figma.getLocalGridStyles();
+        const [paintStyles, textStyles, effectStyles, gridStyles] = await Promise.all([
+          figma.getLocalPaintStylesAsync(),
+          figma.getLocalTextStylesAsync(),
+          figma.getLocalEffectStylesAsync(),
+          figma.getLocalGridStylesAsync(),
+        ]);
 
         paintStyles.forEach(s => {
           styles.paint.push({ id: s.id, name: s.name, key: s.key, remote: s.remote });
@@ -3317,7 +3538,7 @@ export class FigmaClient {
   async applyLibraryStyle(nodeId, styleKey, styleType = 'fill') {
     return await this.eval(`
       (async function() {
-        const node = figma.getNodeById(${JSON.stringify(nodeId)});
+        const node = await figma.getNodeByIdAsync(${JSON.stringify(nodeId)});
         if (!node) return { error: 'Node not found' };
 
         const style = await figma.importStyleByKeyAsync(${JSON.stringify(styleKey)});
@@ -3328,7 +3549,9 @@ export class FigmaClient {
         } else if (type === 'stroke' && 'strokeStyleId' in node) {
           node.strokeStyleId = style.id;
         } else if (type === 'text' && 'textStyleId' in node) {
-          node.textStyleId = style.id;
+          // Async setter: the sync assignment is rejected in dynamic-page
+          // documents, which is every document the plugin path sees.
+          await node.setTextStyleIdAsync(style.id);
         } else if (type === 'effect' && 'effectStyleId' in node) {
           node.effectStyleId = style.id;
         }

--- a/src/lib/command-map.js
+++ b/src/lib/command-map.js
@@ -7,7 +7,7 @@ export const ALL = [
   'setup', 'variables', 'daemon', 'tokens', 'gradient', 'create', 'url-tools',
   'config', 'canvas-ops', 'render', 'export-eval', 'analyze', 'a11y',
   'node-ops', 'slots', 'figjam', 'variants', 'misc', 'extract', 'rules',
-  'snapshot', 'spec', 'instantiate', 'init', 'motion',
+  'snapshot', 'spec', 'instantiate', 'init', 'motion', 'styles',
 ];
 
 /**
@@ -85,6 +85,7 @@ export const COMMAND_MODULES = {
   a11y: ['a11y'],
   node: ['node-ops'],
   slot: ['slots'],
+  styles: ['styles'],
   'export-jsx': ['figjam'],
   'export-storybook': ['figjam'],
   figjam: ['figjam'],

--- a/src/lib/text-styles.js
+++ b/src/lib/text-styles.js
@@ -1,0 +1,105 @@
+/**
+ * Text style lookup and matching.
+ *
+ * These functions run in BOTH worlds: unit tests call them here in Node, and
+ * `figma-client.js` embeds their source (via `.toString()`) into the code it
+ * evaluates inside Figma. That is deliberate — the alternative was writing the
+ * matching rules twice, once testable and once as a template string, and
+ * letting the two drift.
+ *
+ * Consequences for anything added here:
+ *   - no imports, no module-scope references, no closures
+ *   - plain function DECLARATIONS, so they can call each other after being
+ *     re-declared inside the generated code
+ *   - ES2017 at most (the Figma renderer is modern, but keep it boring)
+ *
+ * A "style" is the shape Figma's TextStyle exposes, trimmed to what matching
+ * needs: { id, name, fontName: { family, style }, fontSize }.
+ */
+
+/**
+ * "Semi Bold", "SemiBold" and "semibold" are the same weight as far as a
+ * designer is concerned — Figma just writes it differently per font family.
+ */
+export function normalizeWeight(styleName) {
+  return String(styleName || '').toLowerCase().replace(/[\s_-]/g, '');
+}
+
+/**
+ * Name → style, plus a "tail" alias for slash-grouped names: `Heading/H1` is
+ * also reachable as `H1`. Same rule the variable cache uses for `var:`, so
+ * `textStyle="H1"` and `var:primary` behave alike. The full name always wins.
+ */
+export function buildStyleIndex(styles) {
+  var index = {};
+  var list = styles || [];
+  for (var i = 0; i < list.length; i++) {
+    var s = list[i];
+    if (!s || !s.name) continue;
+    if (!index[s.name]) index[s.name] = s;
+  }
+  for (var j = 0; j < list.length; j++) {
+    var st = list[j];
+    if (!st || !st.name) continue;
+    var slash = st.name.lastIndexOf('/');
+    if (slash < 0) continue;
+    var tail = st.name.slice(slash + 1);
+    if (tail && !index[tail]) index[tail] = st;
+  }
+  return index;
+}
+
+/**
+ * Pick the text style a `<Text>` without an explicit `textStyle` should get.
+ *
+ * Exact matches only: same font size, same weight/italic. Guessing across
+ * sizes would silently restyle text the caller sized on purpose, which is
+ * worse than leaving it unstyled.
+ *
+ * The family is only required when the caller actually wrote `font=` — the
+ * default "Inter" is a fallback, not an intent, and demanding it would mean a
+ * file whose styles use another family could never auto-match.
+ *
+ * @returns {{match:object}} one exact hit
+ *        | {{ambiguous:string[]}} several hits, nothing applied
+ *        | {{nearest:object|null}} no hit, closest by size for the warning
+ */
+export function matchTextStyle(o) {
+  var opts = o || {};
+  var list = opts.styles || [];
+  var size = Number(opts.size);
+  var wanted = normalizeWeight(opts.weightStyle);
+  var family = String(opts.family || '').toLowerCase();
+  var familyExplicit = !!opts.familyExplicit;
+
+  var hits = [];
+  for (var i = 0; i < list.length; i++) {
+    var s = list[i];
+    if (!s || !s.fontName) continue;
+    if (Number(s.fontSize) !== size) continue;
+    if (normalizeWeight(s.fontName.style) !== wanted) continue;
+    if (familyExplicit && String(s.fontName.family).toLowerCase() !== family) continue;
+    hits.push(s);
+  }
+
+  if (hits.length === 1) return { match: hits[0] };
+  if (hits.length > 1) {
+    var names = [];
+    for (var j = 0; j < hits.length; j++) names.push(hits[j].name);
+    return { ambiguous: names };
+  }
+
+  // No hit: report the closest size at the same weight, else the closest size
+  // overall. Purely for the warning text — nothing is applied.
+  var nearest = null;
+  var bestDelta = Infinity;
+  for (var k = 0; k < list.length; k++) {
+    var c = list[k];
+    if (!c || !c.fontName) continue;
+    var delta = Math.abs(Number(c.fontSize) - size);
+    var sameWeight = normalizeWeight(c.fontName.style) === wanted;
+    var score = delta + (sameWeight ? 0 : 1000);
+    if (score < bestDelta) { bestDelta = score; nearest = c; }
+  }
+  return { nearest: nearest };
+}

--- a/tests/render-text-styles.test.js
+++ b/tests/render-text-styles.test.js
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { FigmaClient } from '../src/figma-client.js';
+
+function assertValidJs(code) {
+  assert.doesNotThrow(() => new Function(code), SyntaxError, `bad JS:\n${code}`);
+}
+
+const client = new FigmaClient();
+
+describe('textStyle= on <Text>', () => {
+  it('applies the named style', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text textStyle="Heading/H1">Hi</Text></Frame>');
+    assert.ok(/__applyTextStyle\(el0, "Heading\/H1"/.test(code), code);
+    assert.ok(!/__autoTextStyle\(el0/.test(code), 'an explicit style must not also auto-match');
+    assertValidJs(code);
+  });
+
+  it('is applied after characters are set', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text textStyle="Body/M">Hi</Text></Frame>');
+    const iChars = code.indexOf('el0.characters');
+    const iStyle = code.indexOf('__applyTextStyle(el0');
+    assert.ok(iChars > 0 && iStyle > iChars, 'style must not be applied before the text exists');
+  });
+
+  // Measured against a live Figma: writing fontSize/fontName/lineHeight/
+  // letterSpacing CLEARS textStyleId. So nothing typographic may follow the
+  // style — an "override" would detach the style it overrides.
+  it('never writes typography after applying the style', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text textStyle="Body/M" size={20} lineHeight={30}>Hi</Text></Frame>');
+    const after = code.slice(code.indexOf('__applyTextStyle(el0'));
+    assert.ok(!/el0\.fontSize = /.test(after), after);
+    assert.ok(!/el0\.fontName = /.test(after), after);
+    assert.ok(!/el0\.lineHeight = /.test(after), after);
+    assert.ok(!/el0\.letterSpacing = /.test(after), after);
+  });
+
+  it('hands the conflicting props to the runtime so they can be reported', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text textStyle="Body/M" size={20}>Hi</Text></Frame>');
+    assert.ok(/__applyTextStyle\(el0, "Body\/M", \{"size":20\}\)/.test(code), code);
+  });
+
+  it('still applies align, which is not part of a text style', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text textStyle="Body/M" align="center">Hi</Text></Frame>');
+    const after = code.slice(code.indexOf('__applyTextStyle(el0'));
+    assert.ok(/el0\.textAlignHorizontal = 'CENTER'/.test(after), after);
+  });
+});
+
+describe('automatic text style matching', () => {
+  it('asks for a match when no style is named', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text size={36} weight="bold">Hi</Text></Frame>');
+    assert.ok(/__autoTextStyle\(el0, \{"size":36,"weightStyle":"Bold"/.test(code), code);
+    assertValidJs(code);
+  });
+
+  it('marks the family as explicit only when font= was given', async () => {
+    const withFont = await client.parseJSX('<Frame name="A"><Text font="Fira Sans" size={16}>Hi</Text></Frame>');
+    assert.ok(/"family":"Fira Sans","familyExplicit":true/.test(withFont), withFont);
+
+    const withoutFont = await client.parseJSX('<Frame name="A"><Text size={16}>Hi</Text></Frame>');
+    assert.ok(/"family":"Inter","familyExplicit":false/.test(withoutFont), withoutFont);
+  });
+
+  it('is skipped for rich text with per-range formatting', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text size={16}>plain <b>bold</b></Text></Frame>');
+    assert.ok(!/await globalThis\.__autoTextStyle\(el0/.test(code), code);
+  });
+
+  it('is skipped with auto-style off', async () => {
+    const c2 = new FigmaClient();
+    c2.setAutoTextStyle(false);
+    const code = await c2.parseJSX('<Frame name="A"><Text size={36}>Hi</Text></Frame>');
+    assert.ok(!/__autoTextStyle/.test(code) || !/await globalThis\.__autoTextStyle\(el0/.test(code), code);
+    assertValidJs(code);
+  });
+
+  it('still honors textStyle= with auto-style off', async () => {
+    const c2 = new FigmaClient();
+    c2.setAutoTextStyle(false);
+    const code = await c2.parseJSX('<Frame name="A"><Text textStyle="Body/M">Hi</Text></Frame>');
+    assert.ok(/__applyTextStyle\(el0, "Body\/M"/.test(code), code);
+  });
+});
+
+describe('text style prelude', () => {
+  it('is emitted when the render contains text', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text>Hi</Text></Frame>');
+    assert.ok(/__loadTextStyles/.test(code), code);
+    assert.ok(/getLocalTextStylesAsync/.test(code), 'must use the async API for Safe Mode');
+    assert.ok(/setTextStyleIdAsync/.test(code), code);
+  });
+
+  it('is skipped when there is no text at all', async () => {
+    const code = await client.parseJSX('<Frame name="A" flex="col"><Rect w={10} h={10} bg="#f00"/></Frame>');
+    assert.ok(!/__loadTextStyles/.test(code), 'no text: do not pay for the style query');
+  });
+
+  it('carries the matching rules from src/lib/text-styles.js verbatim', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text>Hi</Text></Frame>');
+    assert.ok(/function matchTextStyle/.test(code), code);
+    assert.ok(/function buildStyleIndex/.test(code), code);
+    assert.ok(/function normalizeWeight/.test(code), code);
+  });
+
+  it('reports applied styles and warnings back to the caller', async () => {
+    const code = await client.parseJSX('<Frame name="A"><Text>Hi</Text></Frame>');
+    assert.ok(/textStyles: __textStyles/.test(code), code);
+  });
+
+  it('works in the render-batch path too', async () => {
+    const code = await client.parseJSXBatch(['<Frame name="A"><Text textStyle="Body/M">Hi</Text></Frame>']);
+    assert.ok(/__loadTextStyles/.test(code), code);
+    assert.ok(/__applyTextStyle\(el0_0, "Body\/M"/.test(code), code);
+    assert.ok(/textStyles \}/.test(code), code);
+    assertValidJs(code);
+  });
+});

--- a/tests/text-styles.test.js
+++ b/tests/text-styles.test.js
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { normalizeWeight, buildStyleIndex, matchTextStyle } from '../src/lib/text-styles.js';
+
+// A trimmed version of a real file's text styles (Fira Sans design system):
+// slash-grouped names, three weights sharing one size, two families.
+const s = (name, family, style, fontSize) => ({ id: 'S:' + name, name, fontName: { family, style }, fontSize });
+const STYLES = [
+  s('Display/XL', 'Fira Sans', 'ExtraBold', 72),
+  s('Heading/H1', 'Fira Sans', 'Bold', 36),
+  s('Heading/H4', 'Fira Sans', 'Bold', 18),
+  s('Body/L', 'Fira Sans', 'Regular', 18),
+  s('Body/M', 'Fira Sans', 'Regular', 16),
+  s('Body/S', 'Fira Sans', 'Regular', 14),
+  s('Label/L', 'Fira Sans', 'SemiBold', 16),
+  s('Label/M', 'Fira Sans', 'SemiBold', 14),
+  s('Code/M', 'Fira Mono', 'Regular', 14),
+];
+
+describe('normalizeWeight', () => {
+  it('treats the spellings of one weight as equal', () => {
+    assert.strictEqual(normalizeWeight('Semi Bold'), normalizeWeight('SemiBold'));
+    assert.strictEqual(normalizeWeight('Extra Bold'), normalizeWeight('extrabold'));
+    assert.strictEqual(normalizeWeight('Bold Italic'), 'bolditalic');
+  });
+
+  it('survives undefined', () => {
+    assert.strictEqual(normalizeWeight(undefined), '');
+  });
+});
+
+describe('buildStyleIndex', () => {
+  const index = buildStyleIndex(STYLES);
+
+  it('registers the full name', () => {
+    assert.strictEqual(index['Heading/H1'].id, 'S:Heading/H1');
+  });
+
+  it('registers the tail as an alias, like var: does', () => {
+    assert.strictEqual(index['H1'].id, 'S:Heading/H1');
+    assert.strictEqual(index['XL'].id, 'S:Display/XL');
+  });
+
+  it('lets the full name win over a colliding tail', () => {
+    const withCollision = [s('M', 'X', 'Regular', 10), ...STYLES];
+    const i2 = buildStyleIndex(withCollision);
+    assert.strictEqual(i2['M'].fontSize, 10, 'a style literally named M wins over Body/M');
+  });
+
+  it('handles an empty list', () => {
+    assert.deepStrictEqual(buildStyleIndex([]), {});
+    assert.deepStrictEqual(buildStyleIndex(undefined), {});
+  });
+});
+
+describe('matchTextStyle', () => {
+  it('matches on size + weight', () => {
+    const r = matchTextStyle({ styles: STYLES, size: 36, weightStyle: 'Bold' });
+    assert.strictEqual(r.match.name, 'Heading/H1');
+  });
+
+  it('accepts a differently spelled weight', () => {
+    const r = matchTextStyle({ styles: STYLES, size: 16, weightStyle: 'Semi Bold' });
+    assert.strictEqual(r.match.name, 'Label/L');
+  });
+
+  it('ignores the family when font= was not given', () => {
+    const r = matchTextStyle({ styles: STYLES, size: 16, weightStyle: 'Regular', family: 'Inter' });
+    assert.strictEqual(r.match.name, 'Body/M', 'the default family is a fallback, not an intent');
+  });
+
+  it('honors the family when font= was given', () => {
+    const r = matchTextStyle({
+      styles: STYLES, size: 14, weightStyle: 'Regular', family: 'Fira Mono', familyExplicit: true,
+    });
+    assert.strictEqual(r.match.name, 'Code/M');
+  });
+
+  it('applies nothing when several styles fit', () => {
+    // 14px Regular exists twice: Body/S (Fira Sans) and Code/M (Fira Mono).
+    const r = matchTextStyle({ styles: STYLES, size: 14, weightStyle: 'Regular' });
+    assert.ok(!r.match);
+    assert.deepStrictEqual(r.ambiguous, ['Body/S', 'Code/M']);
+  });
+
+  it('reports the nearest size at the same weight when nothing fits', () => {
+    const r = matchTextStyle({ styles: STYLES, size: 15, weightStyle: 'Bold' });
+    assert.ok(!r.match);
+    assert.strictEqual(r.nearest.name, 'Heading/H4', '18px Bold is closer than 36px Bold');
+  });
+
+  it('returns nearest: null on an empty style set', () => {
+    const r = matchTextStyle({ styles: [], size: 16, weightStyle: 'Regular' });
+    assert.strictEqual(r.nearest, null);
+  });
+});


### PR DESCRIPTION
Text rendered through the CLI never picked up a **text style**. Every `<Text>` gets raw `fontName` / `fontSize` / `lineHeight`, so a style change in the file can never reach it — and `figma-cli analyze` flags the CLI's own output as "missing style" (`src/commands/analyze.js:40`).

In the file I hit this on: 19 local text styles, 4 more from a library, and not one of them reachable from JSX.

## What this adds

```bash
figma-cli styles          # name, family, weight, size — local and library
```

```jsx
<Text textStyle="Heading/H1">Title</Text>
<Text textStyle="H1">Title</Text>            // tail of a slash-grouped name, like var: aliases
<Text size={36} weight="bold">Title</Text>   // no textStyle= → matched automatically
```

- **`textStyle=`** resolves against local styles **and** the remote (library) styles the document already uses. Figma exposes remote styles by key only, so harvesting the ones in use is the only name-addressable route to them.
- **Automatic matching** when no style is named: applies a style only when *exactly one* shares this text's font size and weight. Several matches or none → nothing is applied and the render says why. The family only has to match when `font=` was written explicitly, since the `"Inter"` default is a fallback, not an intent. `--no-auto-style` turns it off; `textStyle=` keeps working either way.
- Rich text with per-range formatting is skipped by the matching — mixed typography is deliberate.
- `figma-cli styles` exists so an agent can read the names before using them.

## One behaviour is measured, not chosen

Writing `fontSize`, `fontName`, `lineHeight` or `letterSpacing` onto a styled text node **clears `textStyleId`**:

```
before=set  afterFontSizeWrite=CLEARED     # live Figma, Plugin API
afterAlign=true                            # textAlignHorizontal is safe
```

So a CSS-style "explicit prop wins" would detach the style it was overriding. Conflicting props are reported rather than applied:

```
⚠ textStyle="Body/M" wins over size={20} vs 16px — writing those would detach the style, so they were dropped
```

`textAlignHorizontal` is the one typographic prop a text style does not own, and is still applied after.

## Shape

The matching rules live in `src/lib/text-styles.js` as pure functions and are embedded into the generated code via `.toString()`, so the unit tests exercise exactly the code that runs inside Figma — no second copy of the rules as a template string. Both render paths share the child generator, so `render` and `render-batch` behave identically; the result carries `textStyles: { applied, warnings }` and `render` prints a one-line summary.

Everything uses the async style APIs (`getLocalTextStylesAsync`, `getStyleByIdAsync`, `setTextStyleIdAsync`) so the plugin/Safe Mode path works in dynamic-page documents. The previously unused `getLibraryStyles` / `applyLibraryStyle` helpers are modernized along the way — they still called the deprecated sync APIs and a sync `textStyleId` assignment that dynamic-page documents reject.

## Verification

549 tests pass, 26 of them new, none needing Figma. `npm run test:parity`: 10/10.

Live against Figma Desktop:

```
<Text textStyle="Heading/H1">      → Heading/H1  [Fira Sans Bold 36]
<Text textStyle="H1">              → Heading/H1  [Fira Sans Bold 36]
<Text font="Fira Sans" size={18}>  → Body/L      [Fira Sans Regular 18]   (auto)
<Text textStyle="Body/M" size={20}>→ Body/M      [Fira Sans Regular 16]   + conflict warning
<Text textStyle="Gibt/Es/Nicht">   → no style, renders, one clear warning
--no-auto-style                    → unstyled, as asked
```
